### PR TITLE
Detail Page に IGDB API を接続する

### DIFF
--- a/app/api/igdb/[id]/route.ts
+++ b/app/api/igdb/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+import { buildCoverUrl, buildScreenshotUrl, igdbRequest } from "@/lib/igdb/client";
+import type { GameDetailResponse } from "@/types/game-detail";
+
+const GAME_FIELDS = [
+  "id",
+  "name",
+  "summary",
+  "cover.image_id",
+  "genres.name",
+  "screenshots.image_id",
+];
+
+const buildQuery = (id: number) => `fields ${GAME_FIELDS.join(", ")}; where id = ${id}; limit 1;`;
+
+type RawGame = {
+  id: number;
+  name: string;
+  summary?: string | null;
+  cover?: { image_id?: string | null } | null;
+  genres?: Array<{ name?: string | null }> | null;
+  screenshots?: Array<{ image_id?: string | null }> | null;
+};
+
+export async function GET(_req: Request, ctx: { params: { id: string } }) {
+  const id = Number(ctx.params.id);
+  if (!Number.isInteger(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const [game] = await igdbRequest<RawGame[]>("games", buildQuery(id));
+
+    if (!game) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+
+    const genres = (game.genres ?? [])
+      .map((item) => item?.name)
+      .filter((name): name is string => Boolean(name));
+
+    const screenshots = (game.screenshots ?? [])
+      .map((item) => buildScreenshotUrl(item?.image_id))
+      .filter((url): url is string => Boolean(url));
+
+    const responseBody: GameDetailResponse = {
+      id: game.id,
+      name: game.name,
+      summary: game.summary ?? undefined,
+      coverUrl: buildCoverUrl(game.cover?.image_id ?? undefined),
+      genres,
+      screenshots,
+    };
+
+    return NextResponse.json(responseBody, {
+      headers: {
+        "Cache-Control": "public, max-age=60",
+      },
+    });
+  } catch (error) {
+    console.error("IGDB request failed", error);
+    return NextResponse.json({ error: "igdb_request_failed" }, { status: 500 });
+  }
+}

--- a/docs/igdb-integration-plan.md
+++ b/docs/igdb-integration-plan.md
@@ -1,0 +1,73 @@
+# IGDB 連携プラン（ゲーム詳細ページの基盤）
+
+このドキュメントは、GameDetailPage に IGDB から画像・タイトル・概要を取得して表示するまでの手順をまとめたものです。段階的に進められるよう詳細なステップを列挙します。
+
+---
+
+## 1. 前提準備
+- [ ] IGDB Developer Portal で **Client ID** と **Client Secret** を取得する。
+- [ ] プロジェクトの `.env.local` に以下を追記。
+  ```bash
+  IGDB_CLIENT_ID=your_client_id
+  IGDB_CLIENT_SECRET=your_client_secret
+  ```
+- [ ] すでに環境変数を読み込んでいる場合は `npm run dev` の再起動が必要。
+
+## 2. トークン取得ユーティリティの実装
+- [ ] `lib/igdb/auth.ts`（仮）を追加し、以下を実装。
+  1. `requestIgdbToken()` – `https://id.twitch.tv/oauth2/token` に Client Credentials Flow で POST。
+     - body: `client_id`, `client_secret`, `grant_type=client_credentials`
+     - レスポンスから `access_token` と `expires_in` を取得。
+  2. `getIgdbToken()` – 上記関数を使い、メモリにキャッシュして期限切れ前に再取得。
+- [ ] エラーハンドリング（環境変数未設定時は warning を投げるなど）を入れておく。
+
+## 3. ゲーム詳細 API エンドポイント
+- [ ] `app/api/igdb/[id]/route.ts` を作成。
+  - `GET` or `POST` でゲーム ID を受け取り、以下のリクエストを IGDB へ送る。
+    ```sql
+    fields id, name, summary, cover.image_id, genres.name, screenshots.image_id;
+    where id = <gameId>;
+    limit 1;
+    ```
+  - 画像 ID (`image_id`) から実際の URL を組み立てるヘルパーを作成。
+    - 例: `https://images.igdb.com/igdb/image/upload/t_cover_big/{image_id}.jpg`
+  - レスポンスは以下の構造を意識。
+    ```ts
+    type GameDetailResponse = {
+      id: number;
+      name: string;
+      summary?: string;
+      coverUrl?: string;
+      genres: string[];
+      screenshots: string[]; // 必要であれば
+    };
+    ```
+  - IGDB API からデータが取得できない場合のエラーハンドリング（404 など）を準備。
+
+## 4. フロントエンド側の取得ロジック
+- [ ] `app/game/[id]/page.tsx` から、まずサーバー API (`/api/igdb/[id]`) を `fetch`。
+  - `async function getGameDetail(id: string)` を定義。失敗時は null を返す。
+- [ ] 取得データを `GameImage` / `GameOverview` へ渡すための整形を行う。
+  - `GameImage` -> `coverUrl`
+  - `GameOverview` -> `name`, `summary`, `genres`
+- [ ] フロント側のローディング・エラー表示を既存のモックと同等に維持。
+
+## 5. 現行モックとの併用
+- [ ] `.env` が未設定 or IGDB エラー時のフォールバックを検討。
+  - 例: IGDB 取得に失敗したら既存モック (`/api/mocks/[id]`) を参照し、少なくとも画面が表示されるようにする。
+- [ ] 将来的に YouTube API 連携や他セクションにも使いやすい形でレスポンスを設計。
+
+## 6. テスト・確認
+- [ ] ローカルで `npm run dev` を起動し、IGDB から実データが取れているか確認。
+  - 画像・タイトル・概要がモックでなく IGDB の情報に置き換わっているか。
+  - ジャンルリストが正しく表示されるか。
+- [ ] エラー時（トークン未設定等）に適切なログ / UI が出るかを確認。
+
+## 7. 次のステップ（参考）
+- YouTube API 連携用のサーバー API 実装。
+- Review セクションへのデータ接続。
+- IGDB の追加情報（release_dates, involved_companies など）の取得検討。
+
+---
+
+このプランに沿って実装を進めれば、GameDetailPage のベースとなる IGDB 連携部分を安全に構築できます。

--- a/lib/igdb/auth.ts
+++ b/lib/igdb/auth.ts
@@ -1,0 +1,59 @@
+const TOKEN_URL = "https://id.twitch.tv/oauth2/token";
+const EXPIRY_BUFFER_MS = 60_000; // 1 minute safety margin
+
+type CachedToken = {
+  token: string;
+  expiresAt: number;
+};
+
+let cachedToken: CachedToken | null = null;
+
+function assertEnv(value: string | undefined, key: string): string {
+  if (!value) {
+    throw new Error(`IGDB ${key} is not set. Please define ${key} in your environment variables.`);
+  }
+  return value;
+}
+
+async function requestIgdbToken(): Promise<CachedToken> {
+  const clientId = assertEnv(process.env.IGDB_CLIENT_ID, "IGDB_CLIENT_ID");
+  const clientSecret = assertEnv(process.env.IGDB_CLIENT_SECRET, "IGDB_CLIENT_SECRET");
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "client_credentials",
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to obtain IGDB token: ${response.status} ${text}`);
+  }
+
+  const json = (await response.json()) as { access_token: string; expires_in: number };
+
+  const expiresAt = Date.now() + json.expires_in * 1000;
+  cachedToken = {
+    token: json.access_token,
+    expiresAt,
+  };
+
+  return cachedToken;
+}
+
+export async function getIgdbToken(): Promise<string> {
+  if (
+    cachedToken &&
+    cachedToken.expiresAt - EXPIRY_BUFFER_MS > Date.now()
+  ) {
+    return cachedToken.token;
+  }
+
+  const token = await requestIgdbToken();
+  return token.token;
+}

--- a/lib/igdb/client.ts
+++ b/lib/igdb/client.ts
@@ -1,0 +1,39 @@
+import { getIgdbToken } from "./auth";
+
+const IGDB_API_BASE_URL = "https://api.igdb.com/v4";
+
+export async function igdbRequest<T>(endpoint: string, body: string): Promise<T> {
+  const token = await getIgdbToken();
+  const clientId = process.env.IGDB_CLIENT_ID;
+  if (!clientId) {
+    throw new Error("IGDB_CLIENT_ID is not set. Please check your environment variables.");
+  }
+
+  const response = await fetch(`${IGDB_API_BASE_URL}/${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Client-ID": clientId,
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "text/plain",
+    },
+    body,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`IGDB request failed: ${response.status} ${text}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function buildCoverUrl(imageId?: string | null): string | undefined {
+  if (!imageId) return undefined;
+  return `https://images.igdb.com/igdb/image/upload/t_cover_big/${imageId}.jpg`;
+}
+
+export function buildScreenshotUrl(imageId?: string | null): string | undefined {
+  if (!imageId) return undefined;
+  return `https://images.igdb.com/igdb/image/upload/t_screenshot_huge/${imageId}.jpg`;
+}

--- a/types/game-detail.ts
+++ b/types/game-detail.ts
@@ -1,0 +1,16 @@
+export type GameDetailResponse = {
+  id: number;
+  name: string;
+  summary?: string;
+  coverUrl?: string;
+  genres: string[];
+  screenshots: string[];
+};
+
+export type GameOverviewMock = {
+  id: number;
+  name: string;
+  summaryJa?: string | null;
+  summaryEn?: string | null;
+  genres?: string[];
+};


### PR DESCRIPTION

## 概要
- ゲーム詳細ページに IGDB の実データ（カバー画像・概要・ジャンル等）を表示できるようにしました。
- 新しいサーバー API `/api/igdb/[id]` を追加し、ゲーム ID を指定すると IGDB から情報を取得します。
- クライアント側の `GameImage` と `GameOverview` は、IGDB からのレスポンスを優先し、失敗時のみ従来のモック API をフォールバックとして使用します。
- IGDB 連携の手順を `docs/igdb-integration-plan.md` にまとめ、開発メモとして残しました。

## 変更内容
- `lib/igdb/auth.ts` で Client Credentials Flow によるトークン取得／キャッシュを実装。
- `lib/igdb/client.ts` を新設し、IGDB API 呼び出しと画像 URL 組立てを共通化。
- `app/api/igdb/[id]/route.ts` でゲーム詳細を返すサーバー エンドポイントを追加。
- `components/atoms/GameImage.tsx` と `components/atoms/GameOverview.tsx` を IGDB データ対応に改修。
- 共通型 `GameDetailResponse` を `types/game-detail.ts` に切り出し。
- 手順メモ `docs/igdb-integration-plan.md` を作成。

## 動作確認
- `.env.local` に `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET` を設定。
- `npm run dev` を再起動し、`http://localhost:3000/game/<IGDBのゲームID>` にアクセス。
  - カバー画像・概要・ジャンルが IGDB の情報で表示されることを確認。
  - API 直接確認: `http://localhost:3000/api/igdb/<ID>` で JSON が返る。
- `npm run lint`（既存の `app/layout.tsx` の未使用変数警告のみ残存）。

## 注意事項
- IGDB トークン未設定時や API 失敗時は、一旦従来のモックデータ `/api/mocks/[id]` をフォールバックとして利用します。
- DeepL 等による日本語訳はまだ導入していません。英語のままとなります。

## 今後の TODO（参考）
- YouTube API 連携、スクリーンショット表示など追加データの活用。
- 必要であれば DeepL API 等の翻訳を検討。