### PR TITLE
Supabase連携による一言レビュー取得と承認フロー整備

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -1,19 +1,5 @@
-"use client";
-
-import GameHeader from "@/components/molecules/GameHeader";
-import ReviewSwitcher from "@/components/organisms/ReviewSwitcherTable";
+import GameDetailTemplate from "@/components/templates/GameDetailPage/GameDetailTemplate";
 
 export default function GameDetailPage() {
-  return (
-    <div style={{ padding: "20px" }}>
-      <h1>ゲーム詳細ページ</h1>
-      <p>動的ルートでゲームIDを取得します</p>
-
-      {/* GameHeaderコンポーネント（画像 + 概要の統合） */}
-      <div style={{ margin: "20px 0" }}>
-        <GameHeader />
-        <ReviewSwitcher/>
-      </div>
-    </div>
-  );
+  return <GameDetailTemplate />;
 }

--- a/components/molecules/review-table/types.ts
+++ b/components/molecules/review-table/types.ts
@@ -17,6 +17,7 @@ export type YoutubeReview = {
 };
 
 export type OnelinerReview = {
+  id?: string;
   user: string;
   comment: string;
   rating: number;

--- a/components/organisms/QuickReviewForm.tsx
+++ b/components/organisms/QuickReviewForm.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { type FormEvent, useCallback, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Field,
+  Heading,
+  Icon,
+  Input,
+  Stack,
+  Text,
+  Textarea,
+} from "@chakra-ui/react";
+import { useParams } from "next/navigation";
+import { FiSend } from "react-icons/fi";
+
+import {
+  ensureAnonReviewSession,
+  getBrowserSupabaseClient,
+  isSupabaseConfigured,
+} from "@/lib/supabase/browser-client";
+import { RatingStars } from "@/components/atoms/StarRatingDisplay";
+
+type FormState = {
+  userName: string;
+  rating: number;
+  comment: string;
+};
+
+const initialState: FormState = {
+  userName: "",
+  rating: 5,
+  comment: "",
+};
+
+const COMMENT_MAX_LENGTH = 200;
+
+export function QuickReviewForm() {
+  const supabaseConfigured = isSupabaseConfigured();
+  const params = useParams();
+  const rawId =
+    (params as Record<string, string | string[] | undefined>).id ??
+    (params as Record<string, string | string[] | undefined>).gameId;
+  const gameId = useMemo(() => {
+    if (typeof rawId === "string") {
+      return rawId;
+    }
+    if (Array.isArray(rawId) && rawId.length > 0) {
+      return rawId[0];
+    }
+    return null;
+  }, [rawId]);
+
+  const [formState, setFormState] = useState<FormState>(initialState);
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Record<keyof FormState, string | null>>({
+    userName: null,
+    rating: null,
+    comment: null,
+  });
+  const [feedback, setFeedback] = useState<{
+    status: "success" | "error" | "info";
+    message: string;
+  } | null>(null);
+
+  const updateField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setFormState((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const validate = useCallback(() => {
+    const nextErrors: Record<keyof FormState, string | null> = {
+      userName: null,
+      rating: null,
+      comment: null,
+    };
+
+    if (!formState.userName.trim()) {
+      nextErrors.userName = "ユーザー名を入力してください。";
+    } else if (formState.userName.length > 40) {
+      nextErrors.userName = "ユーザー名は40文字以内で入力してください。";
+    }
+
+    const ratingValue = formState.rating;
+    if (!Number.isInteger(ratingValue) || ratingValue < 1 || ratingValue > 5) {
+      nextErrors.rating = "評価は1〜5の範囲で選択してください。";
+    }
+
+    if (!formState.comment.trim()) {
+      nextErrors.comment = "一言コメントを入力してください。";
+    } else if (formState.comment.length > COMMENT_MAX_LENGTH) {
+      nextErrors.comment = `一言コメントは${COMMENT_MAX_LENGTH}文字以内で入力してください。`;
+    }
+
+    setErrors(nextErrors);
+    return Object.values(nextErrors).every((value) => value === null);
+  }, [formState]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (submitting) {
+        return;
+      }
+      if (!gameId) {
+        setFeedback({
+          status: "error",
+          message: "ゲームIDが取得できませんでした。ページを再読み込みしてください。",
+        });
+        return;
+      }
+      if (!supabaseConfigured) {
+        setFeedback({
+          status: "info",
+          message: "レビュー送信はまだできません。Supabase の設定が完了すると投稿できます。",
+        });
+        return;
+      }
+      const isValid = validate();
+      if (!isValid) {
+        return;
+      }
+
+      setSubmitting(true);
+      setFeedback(null);
+
+      try {
+        const client = getBrowserSupabaseClient();
+        await ensureAnonReviewSession(client);
+
+        const { error } = await client.from("oneliner_reviews").insert({
+          game_id: gameId,
+          user_name: formState.userName.trim(),
+          rating: formState.rating,
+          comment: formState.comment.trim(),
+          status: "pending",
+        });
+
+        if (error) {
+          throw error;
+        }
+
+        setFormState(initialState);
+        setFeedback({
+          status: "success",
+          message: "レビューを受け付けました。管理者の承認後に表示されます。",
+        });
+      } catch (error) {
+        console.error("Failed to submit quick review", error);
+        setFeedback({
+          status: "error",
+          message: "レビューの送信に失敗しました。時間をおいて再度お試しください。",
+        });
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      formState.comment,
+      formState.rating,
+      formState.userName,
+      gameId,
+      submitting,
+      supabaseConfigured,
+      validate,
+    ]
+  );
+
+  return (
+    <Box
+      as="section"
+      w="full"
+      maxW={{ base: "100%", xl: "360px" }}
+      bg="rgba(10, 24, 60, 0.92)"
+      borderRadius="24px"
+      border="1px solid rgba(94, 126, 255, 0.28)"
+      boxShadow="0 18px 45px rgba(20, 46, 120, 0.35)"
+      backdropFilter="blur(12px)"
+      px={{ base: 4, md: 5 }}
+      py={{ base: 5, md: 6 }}
+    >
+      <Stack spacing={4}>
+        <Heading
+          as="h2"
+          fontSize="lg"
+          fontWeight="semibold"
+          color="rgba(253, 254, 255, 0.95)"
+          letterSpacing="0.01em"
+        >
+          クイックレビュー投稿
+        </Heading>
+
+        <Stack as="form" onSubmit={handleSubmit} spacing={4}>
+            <Field.Root
+              invalid={Boolean(errors.userName)}
+              disabled={!supabaseConfigured}
+              required
+              gap={2}
+            >
+              <Field.Label color="rgba(253, 254, 255, 0.9)">ユーザー名</Field.Label>
+              <Input
+                value={formState.userName}
+                onChange={(event) => updateField("userName", event.target.value)}
+                placeholder="ニックネームを入力"
+                size="md"
+                disabled={!supabaseConfigured}
+                borderRadius="999px"
+                bg="rgba(12, 28, 68, 0.9)"
+                border="1px solid rgba(98, 130, 255, 0.35)"
+                _placeholder={{ color: "rgba(200, 212, 255, 0.55)" }}
+                color="rgba(253, 254, 255, 0.92)"
+              />
+              {errors.userName && <Field.ErrorText>{errors.userName}</Field.ErrorText>}
+            </Field.Root>
+
+            <Field.Root
+              invalid={Boolean(errors.rating)}
+              disabled={!supabaseConfigured}
+              required
+              gap={2}
+            >
+              <Field.Label color="rgba(253, 254, 255, 0.9)">評価</Field.Label>
+              <Stack direction="row" align="center" spacing={3}>
+                <RatingStars
+                  value={formState.rating}
+                  precision={1}
+                  readOnly={!supabaseConfigured}
+                  size="md"
+                  activeColor="#ffe27a"
+                  idleColor="rgba(255, 255, 255, 0.18)"
+                  onChange={(value) =>
+                    updateField("rating", Math.max(1, Math.min(5, Math.round(value))))
+                  }
+                  ariaLabel="レビュー評価"
+                />
+                <Text fontSize="sm" color="rgba(210, 220, 255, 0.7)">
+                  評価を選択
+                </Text>
+              </Stack>
+              {errors.rating && <Field.ErrorText>{errors.rating}</Field.ErrorText>}
+            </Field.Root>
+
+            <Field.Root
+              invalid={Boolean(errors.comment)}
+              disabled={!supabaseConfigured}
+              required
+              gap={2}
+            >
+              <Field.Label color="rgba(253, 254, 255, 0.9)">一言コメント</Field.Label>
+              <Textarea
+                value={formState.comment}
+                onChange={(event) => updateField("comment", event.target.value)}
+                placeholder="このゲームについての感想を教えてください..."
+                resize="vertical"
+                rows={4}
+                disabled={!supabaseConfigured}
+                borderRadius="20px"
+                bg="rgba(12, 28, 68, 0.9)"
+                border="1px solid rgba(98, 130, 255, 0.35)"
+                _placeholder={{ color: "rgba(200, 212, 255, 0.55)" }}
+                color="rgba(253, 254, 255, 0.92)"
+              />
+              {errors.comment && <Field.ErrorText>{errors.comment}</Field.ErrorText>}
+              <Text
+                color="rgba(255,255,255,0.65)"
+                fontSize="sm"
+                textAlign="right"
+              >
+                {formState.comment.length}/{COMMENT_MAX_LENGTH}
+              </Text>
+            </Field.Root>
+
+            <Button
+              type="submit"
+              variant="outline"
+              borderRadius="999px"
+              border="1px solid rgba(120, 150, 255, 0.6)"
+              color="rgba(222, 232, 255, 0.92)"
+              _hover={{ bg: "rgba(80, 120, 255, 0.18)" }}
+              _active={{ bg: "rgba(80, 120, 255, 0.28)" }}
+              isLoading={submitting}
+              isDisabled={!gameId || !supabaseConfigured}
+              leftIcon={<Icon as={FiSend} />}
+            >
+              レビューを投稿
+            </Button>
+        </Stack>
+
+        <Stack spacing={1}>
+          <Text color="rgba(255,255,255,0.7)" fontSize="sm">
+            ※投稿されたレビューは管理者の承認後に表示されます。
+          </Text>
+          {!supabaseConfigured && (
+            <Text color="rgba(255,200,200,0.85)" fontSize="sm">
+              現在 Supabase の設定が未完了のため、フォームは表示のみとなっています。
+            </Text>
+          )}
+          {feedback && (
+            <Text
+              color={
+                feedback.status === "success"
+                  ? "rgba(138, 255, 191, 0.9)"
+                  : feedback.status === "error"
+                    ? "rgba(255, 180, 180, 0.95)"
+                    : "rgba(160, 200, 255, 0.9)"
+              }
+              fontSize="sm"
+            >
+              {feedback.message}
+            </Text>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/components/templates/GameDetailPage/GameDetailTemplate.tsx
+++ b/components/templates/GameDetailPage/GameDetailTemplate.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Box, Flex, Stack } from "@chakra-ui/react";
+
+import GameHeader from "@/components/molecules/GameHeader";
+import { QuickReviewForm } from "@/components/organisms/QuickReviewForm";
+import ReviewSwitcherTable from "@/components/organisms/ReviewSwitcherTable";
+
+export function GameDetailTemplate() {
+  return (
+    <Stack
+      spacing={{ base: 6, xl: 8 }}
+      w="full"
+      align="center"
+      py={{ base: 6, md: 10 }}
+      px={{ base: 4, md: 8 }}
+    >
+      <Box w="full" maxW="960px">
+        <GameHeader />
+      </Box>
+
+      <Flex
+        w="full"
+        maxW={{ base: "960px", xl: "1200px" }}
+        direction={{ base: "column", xl: "row" }}
+        align={{ base: "stretch", xl: "flex-start" }}
+        gap={{ base: 6, xl: 8 }}
+      >
+        <Box flex="1" minW="0">
+          <ReviewSwitcherTable />
+        </Box>
+        <Box
+          w={{ base: "full", xl: "360px" }}
+          flexShrink={0}
+          position={{ base: "static", xl: "sticky" }}
+          top={{ base: "auto", xl: "96px" }}
+        >
+          <QuickReviewForm />
+        </Box>
+      </Flex>
+    </Stack>
+  );
+}
+
+export default GameDetailTemplate;

--- a/docs/admin-review-approval-plan.md
+++ b/docs/admin-review-approval-plan.md
@@ -1,0 +1,80 @@
+# 管理者承認フロー設計（初心者向け）
+
+## ゴールと全体像
+- 一言コメント（クイックレビュー）が投稿されたら管理者に通知が届く。
+- 管理者が内容を確認し、承認または却下をするとサイトに反映される。
+- 通知はまず Slack の指定チャンネルに送る。承認操作は Web の管理画面から行う。
+- 後から余裕があれば「Slack ボタンで承認／却下」のような拡張も検討できる。
+
+## 全体の流れ（ユーザー → 管理者）
+1. ユーザーがレビュー投稿（既存フォーム）。
+2. Supabase に `pending` 状態で保存。
+3. Slack Webhook 経由で「新しいレビューが来ました」通知。
+4. 管理者は `/admin/reviews` 画面で内容を確認し「承認 / 却下」を選ぶ。
+5. 選択結果に応じて `oneliner_reviews.status` などの値を更新。
+6. 承認済み (`status = approved`) のレビューがサイト上に表示される。
+
+## ステップ別タスク
+
+### 1. Slack 通知の準備
+- **必要なもの**: Slack ワークスペース、Incoming Webhook（または Slack App）。
+- Slack 側で新しい Webhook URL を発行したら、`.env.local` に以下のように保存。
+  ```env
+  SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxx/xxxxx/xxxx
+  ```
+- Next.js で通知ユーティリティを追加。例えば `lib/slack/sendReviewNotification.ts` を作り、投稿内容（ユーザー名 / 評価 / コメント / ゲームURL）を整形して Webhook に送信。
+- 投稿時の Supabase insert が成功したタイミングでこのユーティリティを呼び出す。エラーになっても投稿自体が失敗しないように try/catch で握っておく。
+
+### 2. 承認 API を用意する
+- 実装場所
+  1. **Supabase Edge Function**（本番向けに安全。サービスロールキーを使って DB を更新できる）
+  - `supabase/functions/approve-oneliner-review/index.ts` を作成。
+  - リクエストBody例：
+    ```json
+    {
+      "reviewId": "uuid",
+      "action": "approve", // または "reject"
+      "note": "却下時のメモ（任意）"
+    }
+    ```
+  - 処理内容：
+    - `action === "approve"` → `status = 'approved'`, `approved_at = now()`, `admin_note = note`
+    - `action === "reject"` → `status = 'rejected'`, `approved_at = null`, `admin_note = note`
+    - 結果を JSON で返す。
+  - 認証：
+    - Edge Function に HTTP リクエストが来たら Supabase Auth の JWT を確認。
+    - `auth.getUser()` で取得したユーザーの `role` が `admin` か確認。
+    - 管理画面では Supabase Auth の Email/Password や OAuth を使って `admin` ユーザーでログインしておく必要がある。
+
+### 3. 管理画面 `/admin/reviews` を作る
+- **アクセス制限**:
+  - `app/admin/reviews/page.tsx` を作成。
+  - サーバーコンポーネントで Supabase のサーバークライアントを使い、ログインユーザーの `role` を確認して `admin` 以外はリダイレクト。
+- **UI 構成**:
+  - `status = 'pending'` のレビュー一覧を取得。
+  - 表示項目：ユーザー名、評価、コメント全文、投稿日時、対象ゲームID（またはゲーム名）、承認ボタン、却下ボタン、却下理由入力欄。
+  - ボタン押下で Edge Function を `fetch` し、結果に応じてリストから該当項目を削除 or ステータス表示を更新。
+  - 成功時にはトーストやバナーで反映を伝える。エラー時は理由を表示。
+
+### 4. 通知 → 承認の流れをテスト
+1. ローカル環境で `.env.local` を整えて `npm run dev`。
+2. フォームからレビュー投稿 → Supabase のテーブル（`oneliner_reviews`）に `pending` で入ることを確認。
+3. Slack に通知が飛ぶかチェック。こなければ Webhook URL・ネットワークエラーを確認。
+4. 管理画面で承認 → Edge Function が `status=approved` に更新したかを Supabase の Table Editor で確認。
+5. `ReviewSwitcherTable` が Supabase から承認済みだけを取得する実装になっていれば、承認後に画面をリロードすると表示される。
+
+### 5. 拡張アイデア
+- **Slack から直接操作**: Slack App を作り、Interactive Components を使って「承認」「却下」のボタンを押せるようにする。署名検証やレスポンスの仕組みが必要なので、基本実装が完成してから着手すると良い。
+- **承認結果の通知**: 承認／却下時にも Slack へ通知を送ると、履歴が残って便利。
+- **メールでの承認**: Supabase Functions と SendGrid などを組み合わせてメールベースの承認も可能。
+
+## 参考パス・ファイル構成案
+- Slack通知ユーティリティ: `lib/slack/sendReviewNotification.ts`
+- Edge Function: `supabase/functions/approve-oneliner-review/index.ts`
+- 管理画面サーバークライアント: `lib/supabase/server-client.ts`
+- 管理画面ページ: `app/admin/reviews/page.tsx`（場合によっては `components/templates/Admin/ReviewApproval.tsx` を作る）
+
+## まとめ
+- **最初のゴール**: 投稿時に Slack 通知、管理画面で承認 → Web 反映ができればOK。
+- **注意したい点**: 管理者認証（誰が承認できるか）、Edge Function でのサービスキー取り扱い、Slack Webhook URL の秘匿。
+- 段階的に進めることで、まず通知→Web承認を完成させ、その後余裕があれば Slack ボタン対応や承認結果の再通知などに着手するとスムーズです。

--- a/docs/quick-review-oneliner-plan.md
+++ b/docs/quick-review-oneliner-plan.md
@@ -1,0 +1,321 @@
+# クイックレビュー（一言コメント）投稿機能設計
+
+## 0. まず「何を作るのか」をつかもう
+Switch2Pr にはゲームのレビューを集めて見比べる画面があります。ここに「クイックレビュー」という短いコメント欄を追加したいです。ユーザーは一言コメントと評価（星）を投稿でき、管理者が内容をチェックして問題なければ公開する仕組みを目指しています。公開されたコメントには「参考になったよ！」というサムズアップも付けられるようにします。
+
+### 0-1. ざっくりした流れ
+1. ユーザーがフォームにコメントを書いて送信する。
+2. コメントはすぐには表示されず、データベース（情報を貯める場所）に「承認待ち」として保存される。
+3. 管理者がチェックして OK を出すと「承認済み」に変わり、画面に出てくる。
+4. 他のユーザーは、公開されたコメントにサムズアップを押せる。
+
+### 0-2. 出てくる単語の説明
+- **API**（エーピーアイ）: アプリ同士が情報をやり取りする窓口。例えば「新しいコメントを保存して」とお願いするルール。
+- **GET / POST**（ゲット / ポスト）: API にお願いをするときのやり方。GET は「データをください」、POST は「データを送ります」のイメージ。
+- **Supabase**（スーパーベース）: データベースと API をまとめて提供してくれるサービス。PostgreSQL（ポストグレスキューエル）というデータベースが中に入っている。
+- **Supabase Auth**: Supabase のログイン・ユーザー管理機能。今回の匿名ユーザーや管理者判定に使う。
+- **Supabase Edge Function**（エッジファンクション）: Supabase に置けるサーバーサイドの小さなプログラム。特別な処理だけをここに書ける。
+- **PostgREST**: Supabase が自動で用意してくれる REST API。データベースのテーブルに対して GET / POST などができる。
+- **RLS（Row Level Security）**: データベースの行（レコード）ごとにアクセス許可を制御する仕組み。「この人は承認済みのデータしか見られない」といったルールを設定できる。
+- **Trigger（トリガー）**: データベースで「データが追加されたら自動で何かする」仕組み。今回はサムズアップを押されたら合計値を更新する。
+- **Rate Limit**（レートリミット）: 短時間に連続でリクエスト（API を呼ぶこと）が来た場合に制限する仕組み。スパム投稿を防ぐ目的で使う。
+- **JWT（ジェイダブリューティー）**: ユーザー情報が入ったデジタルの身分証明書。RLS で「この人は管理者か？」などをチェックするときに使う。
+
+この先の章では上の言葉を使いながら詳しく解説します。分からなくなったらここに戻ってください。
+
+## 1. 目指すゴール
+- ゲーム詳細ページに「クイックレビュー投稿」フォームを追加し、ユーザーが一言コメントと評価を投稿できるようにする。
+- 投稿はすぐに公開されず、管理者が承認したものだけが `ReviewSwitcherTable` の「一言コメント」タブに表示される。
+- コメントにはサムズアップ（参考になった）を付けることができ、その数も Supabase で管理する。
+
+## 2. ユースケース
+1. 一般ユーザーがフォームからレビューを送信する → `pending` 状態で保存、画面には案内文のみ表示。
+2. 管理者が未承認リストからレビューを確認し、承認または却下を決める。
+3. 承認済みレビューのみがゲーム詳細の「一言コメント」タブに表示され、閲覧ユーザーはサムズアップを付けられる。
+
+## 3. Supabase でのデータ構造
+
+### 3.1 テーブル: `oneliner_reviews`
+| 列名 | 型 | 説明 |
+| ---- | --- | ---- |
+| `id` | uuid | 主キー |
+| `game_id` | text | ゲーム識別子（`ReviewSwitcherTable` が参照する ID） |
+| `user_name` | text | 投稿者の表示名 |
+| `rating` | smallint | 星評価（1〜5）。省略可なら `nullable` |
+| `comment` | text | 一言コメント。例: 最大140文字 |
+| `status` | text | `pending` / `approved` / `rejected` |
+| `helpful_count` | integer | サムズアップ合計。初期値0 |
+| `created_at` | timestamptz | Supabase の `now()` で自動設定 |
+| `updated_at` | timestamptz | 更新用トリガーで自動設定 |
+| `approved_at` | timestamptz | 承認日時。未承認時は `null` |
+| `admin_note` | text | 却下理由メモなど（任意） |
+
+推奨インデックス:
+- `oneliner_reviews (game_id, status, created_at DESC)` – ゲーム詳細で承認済みレビューを新しい順に取得するため。
+- `oneliner_reviews (status)` – 管理画面で `pending` を一覧化する際に有効。
+
+### 3.2 テーブル: `oneliner_review_votes`
+| 列名 | 型 | 説明 |
+| ---- | --- | ---- |
+| `id` | uuid | 主キー |
+| `review_id` | uuid | `oneliner_reviews.id` への外部キー |
+| `voter_token` | text | 同一ユーザー判定用トークン（ログインなしなら localStorage などで発行） |
+| `created_at` | timestamptz | 投票日時 |
+| `is_active` | boolean | 解除対応したい場合に使用（初期値 true） |
+
+`voter_token` 運用案:
+1. フロント初回アクセス時に `crypto.randomUUID()` で匿名トークンを生成し、`localStorage`（例: `switch2pr_review_token`）に保存。
+2. Supabase クライアントにカスタムヘッダー `x-voter-token` を付与し、`supabase.from("oneliner_review_votes").insert({ review_id, voter_token })` を呼ぶ。
+3. RLS で `auth.jwt() ->> 'voter_token' = voter_token` のように照合できるよう、匿名セッションの JWT に `voter_token` を埋め込む（`supabase.auth.setSession` の `options.data` を利用）。
+
+制約:
+- `oneliner_review_votes` に `UNIQUE (review_id, voter_token)` を設定して二重投票を防ぐ。
+- `helpful_count` はトリガーで `oneliner_review_votes` を元に更新するか、API 側で `INSERT` 成功時に `+1` する。クライアント直アクセス方針ではトリガー方式が堅牢。
+
+`helpful_count` 更新用トリガー例:
+```sql
+create function public.sync_helpful_count() returns trigger as $$
+begin
+  if tg_op = 'INSERT' then
+    update oneliner_reviews
+      set helpful_count = helpful_count + 1,
+          updated_at = now()
+      where id = new.review_id;
+  elsif tg_op = 'DELETE' then
+    update oneliner_reviews
+      set helpful_count = greatest(helpful_count - 1, 0),
+          updated_at = now()
+      where id = old.review_id;
+  end if;
+  return null;
+end;
+$$ language plpgsql security definer;
+
+create trigger trg_sync_helpful_count
+after insert or delete on public.oneliner_review_votes
+for each row execute function public.sync_helpful_count();
+```
+
+## 4. API 設計
+基本的に Next.js 独自 API は用意せず、クライアントから Supabase を直接呼び出す方針。RLS（Row Level Security）を設定して安全性を確保する。管理者承認だけは Supabase Edge Function を 1 本用意し、サービスロールキーで実行する。
+
+| エンドポイント | メソッド | 概要 |
+| ------------- | -------- | ---- |
+| PostgREST `POST /rest/v1/oneliner_reviews` | POST | フォームから直接 Supabase を叩き、`pending` 状態で保存。RLS で挙動を制限する。 |
+| PostgREST `GET /rest/v1/oneliner_reviews` | GET | `select=*` + `status=eq.approved` などのクエリで承認済みのみ取得。 |
+| PostgREST `POST /rest/v1/oneliner_review_votes` | POST | サムズアップ登録。RLS で一意制約＆ `voter_token` との照合を行い、成功後にトリガーで `helpful_count` を更新。 |
+| Edge Function `approve-oneliner-review` | POST | 管理者承認専用。サービスロールキーで実行し、`status` と `approved_at` を更新。呼び出し元は管理画面の Server Action 等から。 |
+
+### 4.1 RLS ポリシー具体例
+`oneliner_reviews` に対する RLS:
+```sql
+alter table public.oneliner_reviews enable row level security;
+
+-- 一般閲覧: 承認済みのみ
+create policy "Select approved reviews" on public.oneliner_reviews
+  for select using (status = 'approved');
+
+-- 投稿: いつでも pending で作成可能
+create policy "Insert pending reviews" on public.oneliner_reviews
+  for insert with check (
+    status = 'pending'
+    and char_length(user_name) between 1 and 40
+    and char_length(comment) between 1 and 140
+    and rating between 1 and 5
+  );
+
+-- 管理者のみ更新・削除
+create policy "Admins can update reviews" on public.oneliner_reviews
+  for update using (auth.jwt() ->> 'role' = 'admin');
+
+create policy "Admins can delete reviews" on public.oneliner_reviews
+  for delete using (auth.jwt() ->> 'role' = 'admin');
+```
+
+`oneliner_review_votes` に対する RLS:
+```sql
+alter table public.oneliner_review_votes enable row level security;
+
+create policy "Insert own vote" on public.oneliner_review_votes
+  for insert with check (
+    auth.jwt() ->> 'voter_token' = voter_token
+  );
+
+create policy "Select own vote" on public.oneliner_review_votes
+  for select using (auth.jwt() ->> 'voter_token' = voter_token);
+```
+
+匿名セッションを使う場合、サーバー側で Supabase Auth の `signInAnonymously` を実行し、取得したセッションに `role` や `voter_token` を `supabase.auth.updateUser({ data: { role: 'anon', voter_token }})` で付与する。
+
+### 4.2 Rate Limit 方針
+- Supabase Functions を使わないクライアント直アクセスでは、トリガー＋ Postgres 拡張 `pg_stat_statements` だけでは制限しづらい。`supabase` プロジェクト設定から [Function Hooks → rate limiter](https://supabase.com/docs/guides/functions/examples/rate-limiter) を利用するか、`net.http_request` + `pg_net` ベースのカスタム関数でリミット前判定を行う。
+- 簡易策として、フロントエンドで `localStorage` タイムスタンプを用い、60 秒以内の二重投稿・連続投票をブロック。バックエンドでは `oneliner_reviews` に `ip_hash` 列を追加し、同一 IP からの連投をトリガーで拒否する案もある。
+
+### 4.3 Edge Function `approve-oneliner-review` の設計
+- エンドポイント例: `POST https://<project>.functions.supabase.co/approve-oneliner-review`
+- リクエストボディ例:
+```json
+{
+  "reviewId": "<uuid>",
+  "action": "approve", // or "reject"
+  "note": "NGワードが含まれるため却下"
+}
+```
+- 認証: 管理画面から呼び出す際に Supabase Auth で admin ロールの JWT を取得し、`Authorization: Bearer <token>` を付与。Edge Function 側で `auth.getUser()` を呼び、`role === 'admin'` をチェック。さらに IP 制限や Basic 認証を併用すると堅牢。
+- 処理フロー:
+  1. `reviewId` で `oneliner_reviews` を検索。
+  2. `action` が `approve` なら `status = 'approved'`, `approved_at = now()`, `admin_note = note` を更新。
+  3. `action` が `reject` なら `status = 'rejected'`, `admin_note = note`, `approved_at = null` に更新。
+  4. 結果を JSON で返す。
+
+## 5. フロントエンド改修
+
+### 5.1 投稿フォームの配置
+- 対象ファイル: `components/templates/GameDetailPage/GameDetailTemplate.tsx`
+- 構成例:
+  - セクションタイトル「クイックレビュー投稿」
+  - 入力項目: ユーザー名、評価（ラジオ or スター）、一言コメント（テキストエリア）
+  - `レビュー投稿` ボタン
+  - ボタン下に「※投稿されたレビューは管理者の承認後に表示されます。」という注意書き
+- UI は Chakra UI で統一感が出る方を採用。
+- 送信時は API を呼び、成功時にフォームを初期化しトーストで案内する。
+
+### 5.2 テーブルへのデータ反映
+- `components/organisms/ReviewSwitcherTable.tsx` の `useEffect` 内で `fetch(/api/mocks)` を呼んでいる箇所を Supabase クライアント呼び出しに置き換える。
+- 取得レスポンスを `OnelinerReview` 型にマッピングし、`helpful_count` を `helpful` プロパティにセットする。
+- サムズアップボタン（`HelpfulVoteButton`）のクリックイベントで Supabase の `insert` を直接実行し、成功時の `helpful_count` で UI を更新する。
+- 既存の localStorage 判定は重複投票防止の UX を担うので維持する。
+
+### 5.3 Supabase クライアントのセットアップ
+- `lib/supabase/browser-client.ts` を作成し、`createBrowserSupabaseClient` で匿名セッションを扱う。`supabase.auth.getSession` → 未ログインなら `signInAnonymously` を実行し、`voter_token` を `localStorage` とユーザーデータに格納。
+- サーバーコンポーネント用に `lib/supabase/server-client.ts` を用意し、`createServerClient` でクッキーからセッションを復元。管理画面ではここから admin ロールの判定を行う。
+- フォーム送信・レビュー取得・サムズアップ処理はそれぞれ `browser-client` を介して実装し、Edge Function 呼び出しのみ Server Action 経由（管理者権限が必要なため）。
+
+## 6. 管理者承認フロー
+- `/admin/reviews` など簡易ページを用意（守秘要件に応じて Basic 認証や Supabase Auth ガードを設定）。
+- `pending` 状態のレビューを一覧で表示し、承認/却下ボタンで Supabase Edge Function `approve-oneliner-review` を叩く。
+- 承認済みは `approved_at` と `status=approved` が保存され、一般ユーザー向けクライアントからの `select` でも表示される。
+
+## 7. テストと品質チェック
+- API レベル: バリデーション（文字数・必須項目）、権限エラー、承認ステータス遷移、サムズアップ二重登録防止をユニットテスト。
+- フロント E2E: 投稿 → 成功メッセージ → 管理者承認 → 一言コメントタブに表示、という流れを確認。
+- セキュリティ: CSRF/XSS 対策、Rate Limit、連投スパム対策（例: 60秒に1回など）を実装。
+- パフォーマンス: 表示側は `status=approved` のみ取得するため、既存表示のパフォーマンスを保てる。
+
+## 8. 今後の拡張のヒント
+- 承認通知（メール/Slack）や、承認時に自動で公開ページへ反映する Webhook を追加。
+- ユーザー認証を導入して、プロフィール情報をレビューに紐付ける。
+- サムズアップの取り消し、コメント編集・削除、モデレーションワークフローの強化などを段階的に検討。
+
+## 9. Supabase 連携ステップ
+
+### 9-1. プロジェクトを用意して環境変数を設定
+1. [Supabase](https://supabase.com/) で新規プロジェクトを作成。
+2. `Project Settings > API` から `Project URL` と `anon public` キーをコピー。
+3. リポジトリ直下に `.env.local` を作成し、以下を貼り付ける（値は自分のものに置き換え）。
+   ```env
+   NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxx.supabase.co
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=xxxxxxxxxxxxxxxxxxxx
+   ```
+4. 既に `npm run dev` を実行している場合は一度停止し、再起動して環境変数を読み込ませる。
+
+### 9-2. テーブルを作成
+Supabase の「SQL Editor」で以下を実行。レビュー本体とサムズアップ（いいね）を保存します。
+```sql
+create extension if not exists pgcrypto;
+
+create table public.oneliner_reviews (
+  id uuid primary key default gen_random_uuid(),
+  game_id text not null,
+  user_name text not null,
+  rating smallint not null check (rating between 1 and 5),
+  comment text not null check (char_length(comment) between 1 and 200),
+  status text not null default 'pending' check (status in ('pending','approved','rejected')),
+  helpful_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  approved_at timestamptz,
+  admin_note text
+);
+
+create table public.oneliner_review_votes (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.oneliner_reviews(id) on delete cascade,
+  voter_token text not null,
+  created_at timestamptz not null default now(),
+  is_active boolean not null default true
+);
+
+create index on public.oneliner_reviews (game_id, status, created_at desc);
+create unique index on public.oneliner_review_votes (review_id, voter_token);
+```
+
+### 9-3. いいね数を自動更新するトリガー
+```sql
+create function public.sync_helpful_count() returns trigger as $$
+begin
+  if tg_op = 'INSERT' then
+    update oneliner_reviews
+      set helpful_count = helpful_count + 1,
+          updated_at = now()
+      where id = new.review_id;
+  elsif tg_op = 'DELETE' then
+    update oneliner_reviews
+      set helpful_count = greatest(helpful_count - 1, 0),
+          updated_at = now()
+      where id = old.review_id;
+  end if;
+  return null;
+end;
+$$ language plpgsql security definer;
+
+create trigger trg_sync_helpful_count
+  after insert or delete on public.oneliner_review_votes
+  for each row execute function public.sync_helpful_count();
+```
+
+### 9-4. Row Level Security を有効化
+```sql
+alter table public.oneliner_reviews enable row level security;
+alter table public.oneliner_review_votes enable row level security;
+
+-- 承認済みレビューだけ閲覧できる
+create policy "Select approved reviews" on public.oneliner_reviews
+  for select using (status = 'approved');
+
+-- 投稿は常に pending で、入力値の長さなどをチェック
+create policy "Insert pending reviews" on public.oneliner_reviews
+  for insert with check (
+    status = 'pending'
+    and char_length(user_name) between 1 and 40
+    and char_length(comment) between 1 and 200
+    and rating between 1 and 5
+  );
+
+-- いいね投票は自分の voter_token のみ Insert/Select 可
+create policy "Insert own vote" on public.oneliner_review_votes
+  for insert with check (auth.jwt() ->> 'voter_token' = voter_token);
+
+create policy "Select own vote" on public.oneliner_review_votes
+  for select using (auth.jwt() ->> 'voter_token' = voter_token);
+```
+
+### 9-5. 匿名ログインを有効化
+ダッシュボードの `Authentication > Providers` で `Anonymous` を ON にする。これでフロントから匿名サインインが可能になる。
+
+### 9-6. フロント側でやること
+- `lib/supabase/browser-client.ts` が `ensureAnonReviewSession` を通じて匿名サインイン＆ `voter_token` 保管を担当。
+- `components/organisms/QuickReviewForm.tsx` は Supabase に直接 `insert` してレビューを `pending` 状態で保存する。
+- 今後は `ReviewSwitcherTable` のデータ取得部分を `fetch(/api/mocks)` から Supabase クエリに書き換えれば、承認済みレビューが表示される。
+
+### 9-7. 動作確認
+1. `.env.local` を設定した状態で `npm run dev` を起動。
+2. `/game/[id]` ページの「クイックレビュー投稿」が入力できるか確認。
+3. 投稿後、Supabase の `Table Editor` で `oneliner_reviews` に `pending` レコードが作成されていれば成功。
+
+### 9-8. 管理者承認をどう実装するか
+- サービスロールキー（`service_role`）は **クライアントで使わない**。Supabase Edge Function や Next.js Route Handler などサーバー側で保持し、承認処理用の API を用意する。
+- 管理画面から承認ボタンを押す → Edge Function を呼び出し → `status` を `approved`、`approved_at` を `now()` に更新。  
+  その際、Supabase Auth で `role = admin` かどうかチェックしておくと安全。
+
+

--- a/lib/supabase/browser-client.ts
+++ b/lib/supabase/browser-client.ts
@@ -1,0 +1,79 @@
+import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? null;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? null;
+
+export function isSupabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+}
+
+let browserClient: SupabaseClient | null = null;
+
+export const REVIEW_VOTER_STORAGE_KEY = "switch2pr_review_token";
+
+export function getBrowserSupabaseClient(): SupabaseClient {
+  if (!isSupabaseConfigured()) {
+    throw new Error("Supabase client requested without configuration");
+  }
+
+  if (browserClient) {
+    return browserClient;
+  }
+
+  browserClient = createClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+    auth: {
+      persistSession: true,
+      storageKey: "switch2pr_auth",
+    },
+  });
+
+  return browserClient;
+}
+
+export async function ensureAnonReviewSession(
+  client = getBrowserSupabaseClient()
+): Promise<{ voterToken: string; session: Session }> {
+  if (!isSupabaseConfigured()) {
+    throw new Error("Supabase session requested without configuration");
+  }
+
+  if (typeof window === "undefined") {
+    throw new Error("ensureAnonReviewSession must be called in the browser");
+  }
+
+  const [sessionResult, storedToken] = await Promise.all([
+    client.auth.getSession(),
+    Promise.resolve(localStorage.getItem(REVIEW_VOTER_STORAGE_KEY)),
+  ]);
+
+  const session = sessionResult.data.session;
+  let voterToken = storedToken;
+
+  if (!session) {
+    const { data, error } = await client.auth.signInAnonymously();
+    if (error) {
+      throw error;
+    }
+    if (!data.session) {
+      throw new Error("Failed to establish anonymous session");
+    }
+    return ensureAnonReviewSession(client);
+  }
+
+  if (!voterToken) {
+    voterToken = crypto.randomUUID();
+    localStorage.setItem(REVIEW_VOTER_STORAGE_KEY, voterToken);
+  }
+
+  const currentMetadata = session.user.user_metadata ?? {};
+  if (currentMetadata.role !== "anon" || currentMetadata.voter_token !== voterToken) {
+    const { error } = await client.auth.updateUser({
+      data: { role: "anon", voter_token: voterToken },
+    });
+    if (error) {
+      throw error;
+    }
+  }
+
+  return { voterToken, session };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^3.27.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@supabase/supabase-js": "^2.75.1",
         "framer-motion": "^12.23.16",
         "next": "15.5.0",
         "react": "19.1.0",
@@ -1415,6 +1416,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.75.1.tgz",
+      "integrity": "sha512-zktlxtXstQuVys/egDpVsargD9hQtG20CMdtn+mMn7d2Ulkzy2tgUT5FUtpppvCJtd9CkhPHO/73rvi5W6Am5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.75.1.tgz",
+      "integrity": "sha512-xO+01SUcwVmmo67J7Htxq8FmhkYLFdWkxfR/taxBOI36wACEUNQZmroXGPl4PkpYxBO7TaDsRHYGxUpv9zTKkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.75.1.tgz",
+      "integrity": "sha512-FiYBD0MaKqGW8eo4Xqu7/100Xm3ddgh+3qHtqS18yQRoglJTFRQCJzY1xkrGS0JFHE2YnbjL6XCiOBXiG8DK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.75.1.tgz",
+      "integrity": "sha512-lBIJ855bUsBFScHA/AY+lxIFkubduUvmwbagbP1hq0wDBNAsYdg3ql80w8YmtXCDjkCwlE96SZqcFn7BGKKJKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.75.1.tgz",
+      "integrity": "sha512-WdGEhroflt5O398Yg3dpf1uKZZ6N3CGloY9iGsdT873uWbkQKoP0wG8mtx98dh0fhj6dAlzBqOAvnlV12cJfzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.75.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.75.1.tgz",
+      "integrity": "sha512-GEPVBvjQimcMd9z5K1eTKTixTRb6oVbudoLQ9JKqTUJnR6GQdBU4OifFZean1AnHfsQwtri1fop2OWwsMv019w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.75.1",
+        "@supabase/functions-js": "2.75.1",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "2.75.1",
+        "@supabase/realtime-js": "2.75.1",
+        "@supabase/storage-js": "2.75.1"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1736,7 +1811,6 @@
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1746,6 +1820,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1766,6 +1846,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7281,6 +7370,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7441,7 +7536,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7493,6 +7587,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7608,6 +7718,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@chakra-ui/react": "^3.27.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@supabase/supabase-js": "^2.75.1",
     "framer-motion": "^12.23.16",
     "next": "15.5.0",
     "react": "19.1.0",


### PR DESCRIPTION
## 概要
- 一言コメントフォームとレビュー表示を Supabase 直結の実装に切り替え、匿名セッションでの投稿と参考投票を本番仕様へ寄せました。
- 今後実装する管理者承認フローと Slack 通知の設計ドキュメントを追加しました。

## 変更内容
- `QuickReviewForm` を改修し、匿名セッション (`signInAnonymously`) を利用して `oneliner_reviews` に `pending` で投稿。
- `ReviewSwitcherTable` を Supabase 取得へ移行し、承認済みデータの表示と `oneliner_review_votes` への投票記録を実装。
- ゲーム詳細テンプレートでクイックレビューカードを sticky 配置に調整。
- `docs/quick-review-oneliner-plan.md` に Supabase セットアップ手順（環境変数〜RLS）を追記。
- `docs/admin-review-approval-plan.md` を新規追加し、管理者承認＋Slack 通知の工程を整理。

## 動作確認
- `npm run lint`  
  - 既知の `app/layout.tsx` における `defaultSystem` 未使用警告のみ（今回変更と関係なし）。
- Supabase 上でテーブル・ポリシーを作成し `.env.local` を設定した状態で以下を確認。
  - レビュー投稿 → `oneliner_reviews` に `pending` レコードが生成。
  - `status=approved` に更新後、テーブルで確認できる。
  - 「参考になった」ボタン押下で `oneliner_review_votes` が増え、表示カウントが更新される。

## 注意事項
- `.env.local` に `NEXT_PUBLIC_SUPABASE_URL` と `NEXT_PUBLIC_SUPABASE_ANON_KEY` がないとフォームは投稿できません。
- Supabase 側で RLS／匿名ログインを有効化し、テーブル作成手順通りに進めておく必要があります。
- Helpful 投票は Supabase の一意制約を利用しているため、DB 側の設定が不完全だとエラーになります。

## 今後の TODO
- Slack Webhook 通知と管理者承認 API（Edge Function）の実装。
- `/admin/reviews` 画面の作成、管理者認証の導線整備。
- 承認／却下時の Slack 通知、Slack ボタンによる承認操作の検討。
- Supabase エラー時のハンドリングやログ整備。
