### PR TITLE
詳細ページのダークテーマ対応を行い、黒背景×グレー基調で統一しました。

### DIFF
--- a/components/atoms/GameImage.tsx
+++ b/components/atoms/GameImage.tsx
@@ -69,13 +69,27 @@ export const GameImage: React.FC = () => {
   // 画面で表示させる部分
   if (isLoading) {
     return (
-      <VStack colorPalette="teal">
-        <Spinner color="colorPalette.600" />
-        <Text color="colorPalette.600">Loading...</Text>
+      <VStack colorPalette="gray">
+        <Spinner color="rgba(255, 255, 255, 0.7)" />
+        <Text color="rgba(255, 255, 255, 0.65)">Loading...</Text>
       </VStack>
     );
   }
-  if (!coverImageUrl) {return <Box>No image</Box>; }// 画像がない場合はメッセージを表示
+  if (!coverImageUrl) {
+    // 画像がない場合はメッセージを表示
+    return (
+      <Box
+        px={4}
+        py={3}
+        borderRadius="lg"
+        border="1px solid rgba(255, 255, 255, 0.08)"
+        bg="rgba(28, 28, 28, 0.9)"
+        color="rgba(255, 255, 255, 0.65)"
+      >
+        No image
+      </Box>
+    );
+  }
   return (
     <Image
       src={coverImageUrl}
@@ -83,6 +97,7 @@ export const GameImage: React.FC = () => {
       htmlWidth="400px"
       htmlHeight="300px"
       borderRadius="lg"
+      border="1px solid rgba(255, 255, 255, 0.08)"
     />
   );
 };

--- a/components/atoms/GameOverview.tsx
+++ b/components/atoms/GameOverview.tsx
@@ -27,9 +27,22 @@ export default function GameOverview() {
 
   const summary = useMemo(() => data?.summary ?? "概要情報は未掲載です。", [data]);
 
+  const cardProps = {
+    p: 4,
+    borderWidth: "1px",
+    borderRadius: "xl",
+    borderColor: "rgba(255, 255, 255, 0.08)",
+    bg: "rgba(28, 28, 28, 0.9)",
+    transition: "background 0.2s ease, border-color 0.2s ease",
+    _hover: {
+      bg: "rgba(42, 42, 42, 0.92)",
+      borderColor: "rgba(255, 255, 255, 0.12)",
+    },
+  } as const;
+
   if (loading) {
     return (
-      <Box p={4} borderWidth="1px" borderRadius="xl">
+      <Box {...cardProps}>
         <Skeleton height="28px" mb={3} />
         <SkeletonText noOfLines={3} />
       </Box>
@@ -38,11 +51,13 @@ export default function GameOverview() {
 
   if (!data) {
     return (
-      <Box p={4} borderWidth="1px" borderRadius="xl">
-        <Heading size="md" mb={2}>
+      <Box {...cardProps}>
+        <Heading size="md" mb={2} color="rgba(255, 255, 255, 0.92)">
           概要
         </Heading>
-        <Text color="gray.500">{error ?? "ゲーム情報が見つかりません。"}</Text>
+        <Text color="rgba(255, 255, 255, 0.6)">
+          {error ?? "ゲーム情報が見つかりません。"}
+        </Text>
       </Box>
     );
   }
@@ -51,12 +66,12 @@ export default function GameOverview() {
   const hasGenres = genres.length > 0;
 
   return (
-    <Box p={4} borderWidth="1px" borderRadius="xl">
-      <Heading size="md" mb={2}>
+    <Box {...cardProps}>
+      <Heading size="md" mb={2} color="rgba(255, 255, 255, 0.95)">
         {data.name}
       </Heading>
 
-      <Text whiteSpace="pre-wrap" lineHeight={1.8}>
+      <Text whiteSpace="pre-wrap" lineHeight={1.8} color="rgba(255, 255, 255, 0.85)">
         {summary}
       </Text>
 
@@ -65,10 +80,19 @@ export default function GameOverview() {
           {genres.map((genre) => (
             <Badge
               key={genre}
-              colorScheme="blue"
+              colorScheme="gray"
               size="lg"
               cursor="pointer"
-              _hover={{ bg: "blue.600" }}
+              bg="rgba(255, 255, 255, 0.08)"
+              color="rgba(255, 255, 255, 0.85)"
+              borderRadius="full"
+              px={3}
+              py={1}
+              border="1px solid rgba(255, 255, 255, 0.12)"
+              _hover={{
+                bg: "rgba(255, 255, 255, 0.16)",
+                color: "rgba(255, 255, 255, 0.95)",
+              }}
               onClick={() => console.log(`ジャンル "${genre}" をクリック`)}
             >
               {genre}

--- a/components/atoms/HelpfulVoteButton.tsx
+++ b/components/atoms/HelpfulVoteButton.tsx
@@ -16,12 +16,12 @@ export const HelpfulVoteButton = ({ count, ...props }: HelpfulVoteButtonProps) =
     justifyContent="center"
     minW="44px"
     py={1}
-    color="rgba(255, 230, 150, 0.95)"
+    color="rgba(255, 255, 255, 0.75)"
     bg="transparent"
     _hover={{
       transform: "translateY(-1px)",
-      color: "rgba(255, 240, 190, 0.98)",
-      bg: "rgba(255, 227, 140, 0.12)",
+      color: "rgba(255, 255, 255, 0.95)",
+      bg: "rgba(255, 255, 255, 0.12)",
     }}
     _active={{ transform: "translateY(0)" }}
     _disabled={{
@@ -29,11 +29,11 @@ export const HelpfulVoteButton = ({ count, ...props }: HelpfulVoteButtonProps) =
       cursor: "default",
       transform: "none",
       bg: "transparent",
-      color: "rgba(255, 230, 150, 0.75)",
+      color: "rgba(255, 255, 255, 0.45)",
     }}
     {...props}
   >
-    <Icon as={LuThumbsUp} boxSize={4.5} color="rgba(255, 227, 140, 0.95)" />
+    <Icon as={LuThumbsUp} boxSize={4.5} color="currentColor" />
     <Text as="span" fontSize="xs" fontWeight="semibold" mt={1} color="inherit">
       {count}
     </Text>

--- a/components/atoms/icons/YouTubeIcon.tsx
+++ b/components/atoms/icons/YouTubeIcon.tsx
@@ -7,7 +7,7 @@ export type YouTubeIconProps = IconProps & {
 };
 
 export const YouTubeIcon = ({
-  accentColor = "#0b1027",
+  accentColor = "rgba(255, 255, 255, 0.85)",
   bodyColor = "transparent",
   ...props
 }: YouTubeIconProps) => (

--- a/components/molecules/GameHeader.tsx
+++ b/components/molecules/GameHeader.tsx
@@ -9,7 +9,18 @@ import GameOverview from "@/components/atoms/GameOverview";
 // 既存のatomsコンポーネントを組み合わせて構成
 export default function GameHeader() {
   return (
-    <Box p={6} borderWidth="1px" borderRadius="xl">
+    <Box
+      p={6}
+      borderWidth="1px"
+      borderRadius="xl"
+      borderColor="rgba(255, 255, 255, 0.08)"
+      bg="rgba(26, 26, 26, 0.95)"
+      transition="background 0.2s ease, border-color 0.2s ease"
+      _hover={{
+        bg: "rgba(40, 40, 40, 0.95)",
+        borderColor: "rgba(255, 255, 255, 0.12)",
+      }}
+    >
       <Flex gap={6} align="flex-start">
         {/* ゲーム画像部分 */}
         <Box flexShrink={0}>

--- a/components/molecules/review-table/ReviewSourceToggle.tsx
+++ b/components/molecules/review-table/ReviewSourceToggle.tsx
@@ -37,13 +37,13 @@ export const ReviewSourceToggle = ({ value, onChange }: ReviewSourceToggleProps)
   <Box
     borderRadius="full"
     width="fit-content"
-    bgGradient="linear(135deg, rgba(56, 198, 255, 0.45), rgba(32, 128, 255, 0.15))"
-    boxShadow="0 12px 35px rgba(32, 178, 255, 0.28)"
+    bg="rgba(255, 255, 255, 0.06)"
+    boxShadow="0 12px 32px rgba(0, 0, 0, 0.4)"
     p="1"
   >
     <HStack
       spacing={2}
-      bg="rgba(10, 16, 40, 0.92)"
+      bg="rgba(32, 32, 32, 0.95)"
       borderRadius="full"
       px={2.5}
       py={1.5}

--- a/components/molecules/review-table/ReviewTableHeader.tsx
+++ b/components/molecules/review-table/ReviewTableHeader.tsx
@@ -21,10 +21,10 @@ export const ReviewTableHeader = ({ icon, title, subtitle, tabs, ...props }: Rev
     <HStack align="flex-start" spacing={3}>
       <Box flexShrink={0}>{icon}</Box>
       <Box>
-        <Text fontSize="xl" fontWeight="bold" color="whiteAlpha.900">
+        <Text fontSize="xl" fontWeight="bold" color="rgba(255, 255, 255, 0.95)">
           {title}
         </Text>
-        <Text fontSize="sm" color="rgba(140, 164, 255, 0.85)">
+        <Text fontSize="sm" color="rgba(255, 255, 255, 0.6)">
           {subtitle}
         </Text>
       </Box>
@@ -39,22 +39,12 @@ export const ReviewTableHeader = ({ icon, title, subtitle, tabs, ...props }: Rev
           px={4}
           py={2}
           border="1px solid"
-          borderColor={
-            tab.isActive
-              ? "rgba(92, 171, 255, 0.6)"
-              : "rgba(255,255,255,0.14)"
-          }
-          bg={
-            tab.isActive
-              ? "linear(135deg, rgba(64, 149, 255, 0.45), rgba(39, 112, 255, 0.3))"
-              : "rgba(255,255,255,0.04)"
-          }
-          color={tab.isActive ? "white" : "rgba(255,255,255,0.75)"}
+          borderColor="rgba(255, 255, 255, 0.16)"
+          bg={tab.isActive ? "rgba(255, 255, 255, 0.16)" : "rgba(255, 255, 255, 0.04)"}
+          color={tab.isActive ? "rgba(255, 255, 255, 0.95)" : "rgba(255,255,255,0.7)"}
           _hover={{
-            bg: tab.isActive
-              ? "linear(135deg, rgba(64, 149, 255, 0.6), rgba(39, 112, 255, 0.45))"
-              : "rgba(255,255,255,0.08)",
-            color: "white",
+            bg: "rgba(255, 255, 255, 0.12)",
+            color: "rgba(255, 255, 255, 0.95)",
           }}
           cursor="default"
           fontWeight="semibold"

--- a/components/molecules/review-table/columns.tsx
+++ b/components/molecules/review-table/columns.tsx
@@ -38,7 +38,7 @@ export const baseColumnsMap: ColumnsMap = {
         renderTruncatedLink(
           row.videoTitle,
           row.url,
-          row.isOfficialLike ? "rgba(255, 240, 246, 0.94)" : "rgba(240, 244, 255, 0.9)"
+          row.isOfficialLike ? "rgba(255, 255, 255, 0.92)" : "rgba(255, 255, 255, 0.85)"
         ),
     },
     {
@@ -48,7 +48,7 @@ export const baseColumnsMap: ColumnsMap = {
         renderTruncatedLink(
           row.channelTitle,
           row.channelUrl,
-          "rgba(255, 236, 238, 0.96)",
+          "rgba(255, 255, 255, 0.85)",
           "200px"
         ),
     },
@@ -57,7 +57,7 @@ export const baseColumnsMap: ColumnsMap = {
       header: "コメント",
       render: (row) => (
         <Text
-          color="rgba(240, 244, 255, 0.95)"
+          color="rgba(255, 255, 255, 0.82)"
           fontSize="sm"
           lineHeight={1.6}
           maxW="560px"
@@ -74,7 +74,7 @@ export const baseColumnsMap: ColumnsMap = {
       key: "author",
       header: "投稿者",
       render: (row) => (
-        <Text color="rgba(235, 244, 255, 0.88)" fontSize="sm">
+        <Text color="rgba(255, 255, 255, 0.75)" fontSize="sm">
           {row.author}
         </Text>
       ),
@@ -83,7 +83,7 @@ export const baseColumnsMap: ColumnsMap = {
       key: "publishedAt",
       header: "公開日",
       render: (row) => (
-        <Text color="rgba(230, 240, 255, 0.88)" fontSize="sm">
+        <Text color="rgba(255, 255, 255, 0.7)" fontSize="sm">
           {formatDate(row.publishedAt)}
         </Text>
       ),
@@ -108,7 +108,7 @@ export const baseColumnsMap: ColumnsMap = {
       key: "comment",
       header: "コメント",
       render: (row) => (
-        <Text color="rgba(255, 255, 255, 1)" fontSize="sm" lineHeight={1.6}>
+        <Text color="rgba(255, 255, 255, 0.85)" fontSize="sm" lineHeight={1.6}>
           {row.comment}
         </Text>
       ),
@@ -119,7 +119,7 @@ export const baseColumnsMap: ColumnsMap = {
       render: (row) => {
         const display = formatDate(row.postedAt);
         return (
-          <Text color="rgba(230, 240, 255, 0.88)" fontSize="sm">
+          <Text color="rgba(255, 255, 255, 0.7)" fontSize="sm">
             {display}
           </Text>
         );

--- a/components/organisms/QuickReviewForm.tsx
+++ b/components/organisms/QuickReviewForm.tsx
@@ -182,12 +182,18 @@ export function QuickReviewForm() {
     <Box
       as="section"
       w="full"
-      bg="rgba(10, 15, 36, 0.92)"
+      bg="rgba(32, 32, 32, 0.95)"
       borderRadius="20px"
-      border="1px solid rgba(94, 126, 255, 0.18)"
-      boxShadow="0 22px 60px rgba(25, 56, 160, 0.28)"
+      border="1px solid rgba(255, 255, 255, 0.08)"
+      boxShadow="0 18px 50px rgba(0, 0, 0, 0.45)"
       px={{ base: 4, md: 6 }}
       py={{ base: 5, md: 6 }}
+      transition="background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease"
+      _hover={{
+        bg: "rgba(42, 42, 42, 0.95)",
+        borderColor: "rgba(255, 255, 255, 0.12)",
+        boxShadow: "0 22px 60px rgba(0, 0, 0, 0.5)",
+      }}
     >
       <Stack spacing={4} as="form" onSubmit={handleSubmit}>
             <Field.Root
@@ -196,7 +202,7 @@ export function QuickReviewForm() {
               required
               gap={2}
             >
-              <Field.Label color="rgba(253, 254, 255, 0.9)">ユーザー名</Field.Label>
+              <Field.Label color="rgba(255, 255, 255, 0.85)">ユーザー名</Field.Label>
               <Input
                 value={formState.userName}
                 onChange={(event) => updateField("userName", event.target.value)}
@@ -204,10 +210,19 @@ export function QuickReviewForm() {
                 size="md"
                 disabled={!supabaseConfigured}
                 borderRadius="999px"
-                bg="rgba(12, 28, 68, 0.9)"
-                border="1px solid rgba(98, 130, 255, 0.35)"
-                _placeholder={{ color: "rgba(200, 212, 255, 0.55)" }}
-                color="rgba(253, 254, 255, 0.92)"
+                bg="rgba(255, 255, 255, 0.05)"
+                border="1px solid rgba(255, 255, 255, 0.12)"
+                _placeholder={{ color: "rgba(255, 255, 255, 0.4)" }}
+                color="rgba(255, 255, 255, 0.9)"
+                _hover={{
+                  borderColor: "rgba(255, 255, 255, 0.2)",
+                  bg: "rgba(255, 255, 255, 0.08)",
+                }}
+                _focusVisible={{
+                  borderColor: "rgba(255, 255, 255, 0.35)",
+                  boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.35)",
+                  bg: "rgba(255, 255, 255, 0.1)",
+                }}
               />
               {errors.userName && <Field.ErrorText>{errors.userName}</Field.ErrorText>}
             </Field.Root>
@@ -218,21 +233,21 @@ export function QuickReviewForm() {
               required
               gap={2}
             >
-              <Field.Label color="rgba(253, 254, 255, 0.9)">評価</Field.Label>
+              <Field.Label color="rgba(255, 255, 255, 0.85)">評価</Field.Label>
               <Stack direction="row" align="center" spacing={3}>
                 <RatingStars
                   value={formState.rating}
                   precision={1}
                   readOnly={!supabaseConfigured}
                   size="md"
-                  activeColor="#ffe27a"
+                  activeColor="#f5c451"
                   idleColor="rgba(255, 255, 255, 0.18)"
                   onChange={(value) =>
                     updateField("rating", Math.max(0, Math.min(5, Math.round(value))))
                   }
                   ariaLabel="レビュー評価"
                 />
-                <Text fontSize="sm" color="rgba(210, 220, 255, 0.7)">
+                <Text fontSize="sm" color="rgba(255, 255, 255, 0.65)">
                   {formState.rating > 0 ? "評価が選択されています" : "星をクリックして評価を選択"}
                 </Text>
               </Stack>
@@ -245,7 +260,7 @@ export function QuickReviewForm() {
               required
               gap={2}
             >
-              <Field.Label color="rgba(253, 254, 255, 0.9)">レビュー内容</Field.Label>
+              <Field.Label color="rgba(255, 255, 255, 0.85)">レビュー内容</Field.Label>
               <Textarea
                 value={formState.comment}
                 onChange={(event) => updateField("comment", event.target.value)}
@@ -254,14 +269,23 @@ export function QuickReviewForm() {
                 rows={4}
                 disabled={!supabaseConfigured}
                 borderRadius="20px"
-                bg="rgba(12, 28, 68, 0.9)"
-                border="1px solid rgba(98, 130, 255, 0.35)"
-                _placeholder={{ color: "rgba(200, 212, 255, 0.55)" }}
-                color="rgba(253, 254, 255, 0.92)"
+                bg="rgba(255, 255, 255, 0.05)"
+                border="1px solid rgba(255, 255, 255, 0.12)"
+                _placeholder={{ color: "rgba(255, 255, 255, 0.4)" }}
+                color="rgba(255, 255, 255, 0.9)"
+                _hover={{
+                  borderColor: "rgba(255, 255, 255, 0.2)",
+                  bg: "rgba(255, 255, 255, 0.08)",
+                }}
+                _focusVisible={{
+                  borderColor: "rgba(255, 255, 255, 0.35)",
+                  boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.35)",
+                  bg: "rgba(255, 255, 255, 0.1)",
+                }}
               />
               {errors.comment && <Field.ErrorText>{errors.comment}</Field.ErrorText>}
               <Text
-                color="rgba(255,255,255,0.65)"
+                color="rgba(255, 255, 255, 0.55)"
                 fontSize="sm"
                 textAlign="right"
               >
@@ -271,12 +295,15 @@ export function QuickReviewForm() {
 
         <Button
               type="submit"
-              variant="outline"
               borderRadius="999px"
-              border="1px solid rgba(120, 150, 255, 0.6)"
-              color="rgba(222, 232, 255, 0.92)"
-              _hover={{ bg: "rgba(80, 120, 255, 0.18)" }}
-              _active={{ bg: "rgba(80, 120, 255, 0.28)" }}
+              border="1px solid rgba(255, 255, 255, 0.24)"
+              color="rgba(255, 255, 255, 0.88)"
+              bg="rgba(255, 255, 255, 0.04)"
+              _hover={{
+                bg: "rgba(255, 255, 255, 0.12)",
+                color: "rgba(255, 255, 255, 0.98)",
+              }}
+              _active={{ bg: "rgba(255, 255, 255, 0.16)" }}
               isLoading={submitting}
               isDisabled={!gameId || !supabaseConfigured}
               leftIcon={<Icon as={FiSend} />}
@@ -284,7 +311,7 @@ export function QuickReviewForm() {
         レビューを投稿
         </Button>
 
-        <Stack spacing={1} pt={2} borderTop="1px solid rgba(94, 126, 255, 0.18)">
+        <Stack spacing={1} pt={2} borderTop="1px solid rgba(255, 255, 255, 0.08)">
           <Text color="rgba(255,255,255,0.7)" fontSize="sm">
             投稿されたレビューは管理者の承認後に表示されます。
           </Text>
@@ -297,10 +324,10 @@ export function QuickReviewForm() {
             <Text
               color={
                 feedback.status === "success"
-                  ? "rgba(138, 255, 191, 0.9)"
+                  ? "rgba(190, 255, 214, 0.9)"
                   : feedback.status === "error"
                     ? "rgba(255, 180, 180, 0.95)"
-                    : "rgba(160, 200, 255, 0.9)"
+                    : "rgba(220, 220, 255, 0.9)"
               }
               fontSize="sm"
             >

--- a/components/organisms/ReviewSwitcherTable.tsx
+++ b/components/organisms/ReviewSwitcherTable.tsx
@@ -38,13 +38,13 @@ const headerIconMap: Record<ReviewTabKey, ReactNode> = {
   youtube: (
     <YouTubeIcon
       boxSize="2.5rem"
-      color="#ff6074"
-      bodyColor="#ff3145"
-      accentColor="#ffffff"
+      color="rgba(255, 255, 255, 0.85)"
+      bodyColor="rgba(255, 255, 255, 0.1)"
+      accentColor="rgba(255, 255, 255, 0.9)"
     />
   ),
-  oneliner: <BubbleIcon boxSize="2.3rem" color="#57c6ff" />,
-  form: <BubbleIcon boxSize="2.3rem" color="#7ed957" />,
+  oneliner: <BubbleIcon boxSize="2.3rem" color="rgba(255, 255, 255, 0.85)" />,
+  form: <BubbleIcon boxSize="2.3rem" color="rgba(255, 255, 255, 0.85)" />,
 };
 
 export default function ReviewSwitcherTable() {
@@ -321,7 +321,7 @@ export default function ReviewSwitcherTable() {
   const currentSortTabs = isFormTab ? [] : sortOptions[activeSource];
 
   const tableContent = (
-    <Box borderRadius="xl" overflowX="auto">
+    <Box borderRadius="xl" overflowX="auto" border="1px solid rgba(255, 255, 255, 0.08)">
       <Table.Root
         size="md"
         variant="simple"
@@ -331,17 +331,16 @@ export default function ReviewSwitcherTable() {
             fontWeight: "semibold",
             textTransform: "none",
             letterSpacing: "0.02em",
-            color: "#FDFEFF",
-            background:
-              "linear-gradient(135deg, rgba(24, 38, 96, 0.9), rgba(19, 33, 82, 0.9))",
-            borderColor: "rgba(52, 75, 160, 0.75)",
-            textShadow: "0 0 8px rgba(8, 14, 40, 0.6)",
+            color: "rgba(255, 255, 255, 0.92)",
+            background: "rgba(34, 34, 34, 0.95)",
+            borderColor: "rgba(255, 255, 255, 0.08)",
+            textShadow: "none",
           },
           td: {
             fontSize: "sm",
             color: "rgba(255,255,255,0.88)",
-            borderColor: "rgba(82, 108, 175, 0.28)",
-            borderBottom: "1px solid rgba(82, 108, 175, 0.28)",
+            borderColor: "rgba(255, 255, 255, 0.06)",
+            borderBottom: "1px solid rgba(255, 255, 255, 0.06)",
           },
           "tbody tr:last-of-type td": {
             borderBottomWidth: 0,
@@ -380,8 +379,8 @@ export default function ReviewSwitcherTable() {
             rows.map((row, index) => (
               <Table.Row
                 key={`${activeSource}-${index}`}
-                bg="rgba(255,255,255,0.015)"
-                _hover={{ bg: "rgba(255,255,255,0.05)" }}
+                bg="rgba(255, 255, 255, 0.02)"
+                _hover={{ bg: "rgba(255, 255, 255, 0.08)" }}
                 transition="background 0.2s ease"
               >
                 {columns.map((column) => (
@@ -406,13 +405,18 @@ export default function ReviewSwitcherTable() {
       <Box
         w="full"
         maxW="960px"
-        bg="rgba(16, 22, 54, 0.94)"
+        bg="rgba(26, 26, 26, 0.95)"
         borderRadius="2xl"
-        border="1px solid rgba(94, 126, 255, 0.22)"
-        boxShadow="0 24px 60px rgba(24, 64, 216, 0.25)"
+        border="1px solid rgba(255, 255, 255, 0.08)"
+        boxShadow="0 24px 60px rgba(0, 0, 0, 0.4)"
         px={{ base: 4, md: 6 }}
         py={{ base: 5, md: 6 }}
         textAlign="left"
+        transition="background 0.2s ease, border-color 0.2s ease"
+        _hover={{
+          bg: "rgba(36, 36, 36, 0.95)",
+          borderColor: "rgba(255, 255, 255, 0.12)",
+        }}
       >
         <Stack spacing={5}>
           <ReviewTableHeader
@@ -423,7 +427,7 @@ export default function ReviewSwitcherTable() {
           />
 
           {!isFormTab && error && (
-            <Text color="rgba(255, 102, 132, 0.85)" fontSize="sm">
+            <Text color="rgba(255, 180, 180, 0.85)" fontSize="sm">
               {error}
             </Text>
           )}

--- a/components/templates/GameDetailPage/GameDetailTemplate.tsx
+++ b/components/templates/GameDetailPage/GameDetailTemplate.tsx
@@ -11,8 +11,12 @@ export function GameDetailTemplate() {
       spacing={{ base: 6, xl: 8 }}
       w="full"
       align="center"
+      justify="flex-start"
+      minH="100vh"
       py={{ base: 6, md: 10 }}
       px={{ base: 4, md: 8 }}
+      bg="#050505"
+      color="rgba(243, 244, 246, 0.92)"
     >
       <Box w="full" maxW="960px">
         <GameHeader />


### PR DESCRIPTION
## 概要
- 詳細ページのダークテーマ対応を行い、黒背景×グレー基調で統一しました。

## 変更内容
- `components/templates/GameDetailPage/GameDetailTemplate.tsx`：ページ全体の背景・テキスト色をダークテーマ向けに設定。
- `components/molecules/GameHeader.tsx` / `components/atoms/GameOverview.tsx` / `components/atoms/GameImage.tsx`：カードや画像枠をグレー基調に整え、ホバーで白みがかる演出を追加。
- `components/organisms/ReviewSwitcherTable.tsx` / `components/organisms/QuickReviewForm.tsx`：レビュー表示エリアとフォームの配色・ホバー挙動をダークテーマ用に調整。
- `components/molecules/review-table/config.ts` / `components/molecules/review-table/ReviewSourceToggle.tsx`：タブのアクティブ色を元の赤/青/緑に戻しつつ新テーマとなじむよう修正。
- その他（ヘッダー文、アイコン、テキストカラー等）を新テーマに合わせて微調整。

## 動作確認
- `npm run lint`（既存の `app/layout.tsx` による未使用変数警告が1件発生）

## 注意事項
- `app/layout.tsx` 内の未使用変数 `defaultSystem` による ESLint 警告は未対応のままです。別途対応を検討してください。

## 今後のTODO
1. Chakra UI テーマでカラートークンを定義し、スタイルを変数化して再利用性を高める。
2. `app/layout.tsx` の未使用変数警告を解消する。
3. 他ページについてもダークテーマへ統一するか検討する。
