### PR TITLE
詳細ページのレビューソート機能とサムズアップUIを更新

### DIFF
--- a/components/atoms/HelpfulVoteButton.tsx
+++ b/components/atoms/HelpfulVoteButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Text } from "@chakra-ui/react";
+import { Button, HStack, Icon, Text } from "@chakra-ui/react";
 import type { ButtonProps } from "@chakra-ui/react";
 import { LuThumbsUp } from "react-icons/lu";
 
@@ -11,17 +11,18 @@ export const HelpfulVoteButton = ({ count, ...props }: HelpfulVoteButtonProps) =
     variant="ghost"
     size="sm"
     display="inline-flex"
-    flexDirection="column"
     alignItems="center"
     justifyContent="center"
-    minW="44px"
-    py={1}
+    minW="42px"
+    px={2}
+    py={2}
+    borderRadius="999px"
     color="rgba(255, 255, 255, 0.75)"
     bg="transparent"
     _hover={{
       transform: "translateY(-1px)",
       color: "rgba(255, 255, 255, 0.95)",
-      bg: "rgba(255, 255, 255, 0.12)",
+      bg: "rgba(255, 255, 255, 0.16)",
     }}
     _active={{ transform: "translateY(0)" }}
     _disabled={{
@@ -33,9 +34,11 @@ export const HelpfulVoteButton = ({ count, ...props }: HelpfulVoteButtonProps) =
     }}
     {...props}
   >
-    <Icon as={LuThumbsUp} boxSize={4.5} color="currentColor" />
-    <Text as="span" fontSize="xs" fontWeight="semibold" mt={1} color="inherit">
-      {count}
-    </Text>
+    <HStack spacing={2} align="center">
+      <Icon as={LuThumbsUp} boxSize={4} color="inherit" />
+      <Text as="span" fontSize="sm" fontWeight="semibold" color="inherit">
+        {count}
+      </Text>
+    </HStack>
   </Button>
 );

--- a/components/molecules/review-table/ReviewTableHeader.tsx
+++ b/components/molecules/review-table/ReviewTableHeader.tsx
@@ -42,11 +42,12 @@ export const ReviewTableHeader = ({ icon, title, subtitle, tabs, ...props }: Rev
           borderColor="rgba(255, 255, 255, 0.16)"
           bg={tab.isActive ? "rgba(255, 255, 255, 0.16)" : "rgba(255, 255, 255, 0.04)"}
           color={tab.isActive ? "rgba(255, 255, 255, 0.95)" : "rgba(255,255,255,0.7)"}
+          onClick={tab.onClick}
           _hover={{
             bg: "rgba(255, 255, 255, 0.12)",
             color: "rgba(255, 255, 255, 0.95)",
           }}
-          cursor="default"
+          cursor={tab.onClick ? "pointer" : "default"}
           fontWeight="semibold"
         >
           {tab.label}

--- a/components/molecules/review-table/config.ts
+++ b/components/molecules/review-table/config.ts
@@ -1,4 +1,9 @@
-import type { ReviewTabKey, Source, SortTab } from "./types";
+import type {
+  ReviewTabKey,
+  SortOption,
+  YoutubeSortKey,
+  OnelinerSortKey,
+} from "./types";
 
 export const tabLabels: Record<ReviewTabKey, string> = {
   youtube: "YouTube口コミ",
@@ -46,14 +51,17 @@ export const tabButtonThemes: Record<ReviewTabKey, {
 
 export const tabOrder: ReviewTabKey[] = ["youtube", "oneliner", "form"];
 
-export const sortOptions: Record<Source, SortTab[]> = {
+export const sortOptions: {
+  youtube: SortOption<YoutubeSortKey>[];
+  oneliner: SortOption<OnelinerSortKey>[];
+} = {
   youtube: [
-    { label: "新着順", isActive: true },
-    { label: "高評価順" },
+    { label: "新着順", value: "published_desc" },
+    { label: "高評価順", value: "like_desc" },
   ],
   oneliner: [
-    { label: "新着順", isActive: true },
-    { label: "評価順" },
-    { label: "参考になった順" },
+    { label: "新着順", value: "posted_desc" },
+    { label: "評価順", value: "rating_desc" },
+    { label: "参考になった順", value: "helpful_desc" },
   ],
 };

--- a/components/molecules/review-table/types.ts
+++ b/components/molecules/review-table/types.ts
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 export type Source = "youtube" | "oneliner";
 export type ReviewTabKey = Source | "form";
+export type YoutubeSortKey = "published_desc" | "like_desc";
+export type OnelinerSortKey = "posted_desc" | "rating_desc" | "helpful_desc";
 
 export type YoutubeReview = {
   videoId: string;
@@ -50,4 +52,10 @@ export type ColumnsMap = {
 export type SortTab = {
   label: string;
   isActive?: boolean;
+  onClick?: () => void;
+};
+
+export type SortOption<Value extends string = string> = {
+  label: string;
+  value: Value;
 };

--- a/components/organisms/ReviewSwitcherTable.tsx
+++ b/components/organisms/ReviewSwitcherTable.tsx
@@ -12,7 +12,15 @@ import { ReviewTableHeader } from "../molecules/review-table/ReviewTableHeader";
 import { baseColumnsMap } from "../molecules/review-table/columns";
 import { sortOptions } from "../molecules/review-table/config";
 import { buildHelpfulStorageKey } from "../molecules/review-table/utils";
-import type { GameReviews, OnelinerReview, ReviewTabKey, Source, YoutubeReview } from "../molecules/review-table/types";
+import type {
+  GameReviews,
+  OnelinerReview,
+  OnelinerSortKey,
+  ReviewTabKey,
+  Source,
+  YoutubeReview,
+  YoutubeSortKey,
+} from "../molecules/review-table/types";
 import { QuickReviewForm } from "./QuickReviewForm";
 import type { GameDetailResponse } from "@/types/game-detail";
 import {
@@ -57,6 +65,13 @@ export default function ReviewSwitcherTable() {
 
   const [tab, setTab] = useState<ReviewTabKey>("youtube");
   const [reviews, setReviews] = useState<GameReviews>({ youtube: [], oneliner: [] });
+  const [sortKeys, setSortKeys] = useState<{
+    youtube: YoutubeSortKey;
+    oneliner: OnelinerSortKey;
+  }>({
+    youtube: "published_desc",
+    oneliner: "posted_desc",
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [votedKeys, setVotedKeys] = useState<string[]>([]);
@@ -318,7 +333,57 @@ export default function ReviewSwitcherTable() {
     ? "投稿されたレビューは管理者の承認後に表示されます。"
     : subtitleTemplate[activeSource](total);
   const headerIcon = headerIconMap[tab];
-  const currentSortTabs = isFormTab ? [] : sortOptions[activeSource];
+  const currentSortTabs = useMemo(() => {
+    if (isFormTab) {
+      return [];
+    }
+    if (activeSource === "youtube") {
+      return sortOptions.youtube.map((option) => ({
+        label: option.label,
+        isActive: option.value === sortKeys.youtube,
+        onClick: () => {
+          setSortKeys((prev) => ({ ...prev, youtube: option.value }));
+        },
+      }));
+    }
+    return sortOptions.oneliner.map((option) => ({
+      label: option.label,
+      isActive: option.value === sortKeys.oneliner,
+      onClick: () => {
+        setSortKeys((prev) => ({ ...prev, oneliner: option.value }));
+      },
+    }));
+  }, [activeSource, isFormTab, sortKeys.oneliner, sortKeys.youtube]);
+
+  const sortedRows = useMemo(() => {
+    if (isFormTab) {
+      return [] as typeof rows;
+    }
+    if (activeSource === "youtube") {
+      const base = [...(rows as YoutubeReview[])];
+      if (sortKeys.youtube === "like_desc") {
+        base.sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0));
+      } else {
+        base.sort(
+          (a, b) =>
+            new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+        );
+      }
+      return base;
+    }
+    const base = [...(rows as OnelinerReview[])];
+    if (sortKeys.oneliner === "rating_desc") {
+      base.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+    } else if (sortKeys.oneliner === "helpful_desc") {
+      base.sort((a, b) => (b.helpful ?? 0) - (a.helpful ?? 0));
+    } else {
+      base.sort(
+        (a, b) =>
+          new Date(b.postedAt ?? 0).getTime() - new Date(a.postedAt ?? 0).getTime()
+      );
+    }
+    return base;
+  }, [activeSource, isFormTab, rows, sortKeys.oneliner, sortKeys.youtube]);
 
   const tableContent = (
     <Box borderRadius="xl" overflowX="auto" border="1px solid rgba(255, 255, 255, 0.08)">
@@ -367,7 +432,7 @@ export default function ReviewSwitcherTable() {
                 <Text color="rgba(255,255,255,0.65)">口コミを読み込み中...</Text>
               </Table.Cell>
             </Table.Row>
-          ) : rows.length === 0 ? (
+          ) : sortedRows.length === 0 ? (
             <Table.Row>
               <Table.Cell colSpan={columns.length}>
                 <Text color="rgba(255,255,255,0.6)">
@@ -376,7 +441,7 @@ export default function ReviewSwitcherTable() {
               </Table.Cell>
             </Table.Row>
           ) : (
-            rows.map((row, index) => (
+            sortedRows.map((row, index) => (
               <Table.Row
                 key={`${activeSource}-${index}`}
                 bg="rgba(255, 255, 255, 0.02)"


### PR DESCRIPTION
## 概要
- 詳細ページのレビュー表示をダークテーマ仕様に統一しつつ、レビューソートとサムズアップの機能差分を取り込みました。

## 変更内容
- `components/templates/GameDetailPage/GameDetailTemplate.tsx` ほか: ページ全体を黒背景＋灰系カードに刷新し、ホバー時に白みがかる演出を追加。
- `components/organisms/ReviewSwitcherTable.tsx`: ソート状態を管理して YouTube／一言コメントの並び替えが働くよう復旧。
- `components/molecules/review-table/config.ts` / `types.ts` / `ReviewTableHeader.tsx`: ソートタブの値・型・クリックイベントを再整備。
- `components/atoms/HelpfulVoteButton.tsx`: サムズアップボタンを横並びレイアウト＆新カラーに調整し、仕様変更へ追従。

## 動作確認
- `npm run lint`（既知の `app/layout.tsx` 未使用変数警告のみ）

## 注意事項
- `app/layout.tsx` の `defaultSystem` 未使用警告は未対応のままです。