### PR TITLE
ホーム画面の表示高速化と詳細ページの不要翻訳処理削除

### DIFF
--- a/app/api/admin/games/route.ts
+++ b/app/api/admin/games/route.ts
@@ -68,6 +68,7 @@ export async function GET() {
         featuredNewRelease: config?.is_new_release ?? false,
         featuredPopular: config?.is_popular ?? false,
         featuredRecommended: config?.is_recommended ?? false,
+        firstReleaseDate: game.first_release_date ?? null,
         platforms: mapPlatforms(game.platforms ?? null),
         displayName: config?.display_name ?? null,
         sortOrder: config?.sort_order ?? null,

--- a/app/api/games/highlights/route.ts
+++ b/app/api/games/highlights/route.ts
@@ -6,6 +6,7 @@ import { buildCoverUrl, igdbRequest } from "@/lib/api/igdb";
 import { mapGenres, mapPlatforms } from "@/lib/gameMetadata";
 import type { Game } from "@/types/game";
 
+// IGDB から取得するフィールドを共通化しておく。
 const GAME_FIELDS = [
   "id",
   "name",
@@ -21,13 +22,16 @@ const GAME_FIELDS = [
   "release_dates.region",
 ];
 
-
+// 新作・人気の検索条件をまとめて管理。
 const NEW_RELEASE_LIMIT = 30;
 const POPULAR_LIMIT = 30;
+const DLC_LIMIT = 30;
+const MANUFACTURER_LIMIT = 30;
 const POPULAR_MIN_RATING = 60;
 const POPULAR_MIN_RATING_COUNT = 10;
 const NEW_RELEASE_YEAR_THRESHOLD = 2025;
 const POPULAR_YEAR_THRESHOLD = 2019;
+const DLC_CATEGORIES = [1, 4];
 
 type RawGame = {
   id: number;
@@ -35,13 +39,20 @@ type RawGame = {
   summary?: string | null;
   cover?: { image_id?: string | null } | null;
   genres?: Array<{ name?: string | null }> | null;
-  platforms?: Array<{ abbreviation?: string | null; name?: string | null }> | null;
+  platforms?: Array<{
+    abbreviation?: string | null;
+    name?: string | null;
+  }> | null;
   total_rating?: number | null;
   total_rating_count?: number | null;
   first_release_date?: number | null;
-  release_dates?: Array<{ date?: number | null; region?: number | null }> | null;
+  release_dates?: Array<{
+    date?: number | null;
+    region?: number | null;
+  }> | null;
 };
 
+// IGDB からのレスポンスで重複 ID が混ざる場合があるのでユニーク化する。
 function uniqueById(games: RawGame[]): RawGame[] {
   const seen = new Set<number>();
   return games.filter((game) => {
@@ -52,6 +63,7 @@ function uniqueById(games: RawGame[]): RawGame[] {
   });
 }
 
+// API で利用する Game 型に整形。個別フラグは overrides で付与する。
 function mapGame(raw: RawGame, overrides?: Partial<Game>): Game {
   return {
     id: String(raw.id),
@@ -64,6 +76,7 @@ function mapGame(raw: RawGame, overrides?: Partial<Game>): Game {
     visibleOnCategory: true,
     displayName: null,
     sortOrder: null,
+    firstReleaseDate: raw.first_release_date ?? null,
     featuredNewRelease: false,
     featuredPopular: false,
     featuredRecommended: false,
@@ -75,17 +88,19 @@ function buildNewReleaseQuery(now: number, offset: number) {
   const earliest = Math.floor(
     new Date(`${NEW_RELEASE_YEAR_THRESHOLD}-01-01T00:00:00Z`).getTime() / 1000
   );
+
   return `
     fields ${GAME_FIELDS.join(", ")};
-    where release_dates.date != null
-      & release_dates.date <= ${now}
-      & release_dates.date >= ${earliest};
-    sort release_dates.date desc;
+    where first_release_date != null
+      & first_release_date <= ${now}
+      & first_release_date >= ${earliest};
+    sort first_release_date desc;
     limit ${NEW_RELEASE_LIMIT};
     offset ${offset};
   `;
 }
 
+// 人気用の IGDB クエリを組み立てる。
 function buildPopularQuery(now: number, offset: number) {
   const earliest = Math.floor(
     new Date(`${POPULAR_YEAR_THRESHOLD}-01-01T00:00:00Z`).getTime() / 1000
@@ -105,31 +120,86 @@ function buildPopularQuery(now: number, offset: number) {
   `;
 }
 
+function buildManufacturerQuery(now: number, offset: number, companies: string[]) {
+  const earliest = Math.floor(
+    new Date(`${NEW_RELEASE_YEAR_THRESHOLD}-01-01T00:00:00Z`).getTime() / 1000
+  );
+  const companyFilter = companies
+    .map((name) => `involved_companies.company.name = "${name.replace(/"/g, '\\"')}"`)
+    .join(" | ");
+
+  return `
+    fields ${GAME_FIELDS.join(", ")};
+    where first_release_date != null
+      & first_release_date <= ${now}
+      & first_release_date >= ${earliest}
+      & (${companyFilter});
+    sort first_release_date desc;
+    limit ${MANUFACTURER_LIMIT};
+    offset ${offset};
+  `;
+}
+
+function buildDlcQuery(now: number, offset: number) {
+  const earliest = Math.floor(
+    new Date(`${NEW_RELEASE_YEAR_THRESHOLD}-01-01T00:00:00Z`).getTime() / 1000
+  );
+  const categoryFilter = DLC_CATEGORIES.join(",");
+
+  return `
+    fields ${GAME_FIELDS.join(", ")};
+    where first_release_date != null
+      & first_release_date <= ${now}
+      & first_release_date >= ${earliest}
+      & category = (${categoryFilter});
+    sort first_release_date desc;
+    limit ${DLC_LIMIT};
+    offset ${offset};
+  `;
+}
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const category = searchParams.get("category");
   const rawOffset = Number.parseInt(searchParams.get("offset") ?? "0", 10);
   const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
+  const manufacturerCompanies = searchParams.getAll("company");
 
   const now = Math.floor(Date.now() / 1000);
 
   try {
-    if (category === "new" || category === "popular") {
+    // `company` クエリが指定されている場合はメーカー別の新着ゲームを返す。
+    if (manufacturerCompanies.length > 0) {
+      const query = buildManufacturerQuery(now, offset, manufacturerCompanies);
+      const response = await igdbRequest<RawGame[]>("games", query);
+      const items = uniqueById(response).map((raw) => mapGame(raw));
+
+      return NextResponse.json({
+        items,
+        hasMore: response.length === MANUFACTURER_LIMIT,
+      });
+    }
+
+    // category が指定されている場合は無限スクロール用の追加データを返す。
+    if (category === "new" || category === "popular" || category === "dlc") {
       const isNew = category === "new";
-      const limit = isNew ? NEW_RELEASE_LIMIT : POPULAR_LIMIT;
-      const query = isNew
-        ? buildNewReleaseQuery(now, offset)
-        : buildPopularQuery(now, offset);
+      const limit = category === "dlc" ? DLC_LIMIT : isNew ? NEW_RELEASE_LIMIT : POPULAR_LIMIT;
+      const query = category === "dlc"
+        ? buildDlcQuery(now, offset)
+        : isNew
+          ? buildNewReleaseQuery(now, offset)
+          : buildPopularQuery(now, offset);
 
       const response = await igdbRequest<RawGame[]>("games", query);
-      const items =
-        isNew
-          ? uniqueById(response).map((raw) =>
-              mapGame(raw, { featuredNewRelease: true })
-            )
-          : uniqueById(response).map((raw) =>
-              mapGame(raw, { featuredPopular: true })
-            );
+      const items = isNew
+        ? uniqueById(response).map((raw) =>
+            mapGame(raw, { featuredNewRelease: true })
+          )
+        : category === "dlc"
+        ? uniqueById(response).map((raw) => mapGame(raw))
+        : uniqueById(response).map((raw) =>
+            mapGame(raw, { featuredPopular: true })
+          );
 
       return NextResponse.json({
         items,
@@ -137,6 +207,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    // 初期ロード時は新作・人気をまとめて取得。
     const [newReleaseResponse, popularResponse] = await Promise.all([
       igdbRequest<RawGame[]>("games", buildNewReleaseQuery(now, 0)),
       igdbRequest<RawGame[]>("games", buildPopularQuery(now, 0)),
@@ -157,6 +228,9 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error("Failed to fetch highlight games", error);
-    return NextResponse.json({ error: "failed_to_fetch_highlights" }, { status: 500 });
+    return NextResponse.json(
+      { error: "failed_to_fetch_highlights" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -103,6 +103,7 @@ export async function GET() {
           featuredNewRelease: config?.is_new_release ?? false,
           featuredPopular: config?.is_popular ?? false,
           featuredRecommended: config?.is_recommended ?? false,
+          firstReleaseDate: game.first_release_date ?? null,
           displayName: config?.display_name ?? null,
           sortOrder: config?.sort_order ?? null,
         } satisfies Game;

--- a/components/molecules/GameCard/GameCard.tsx
+++ b/components/molecules/GameCard/GameCard.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { Box, Stack, Text, Flex, Badge } from "@chakra-ui/react";
 import { CATEGORY_GRADIENTS } from "./constants";
+import Image from "next/image";
 
 interface GameCardProps {
   title: string;
@@ -82,18 +83,14 @@ const GameCard: React.FC<GameCardProps> = memo(({
         h="full"
       >
         <Box
+          aria-label={title}
           bgGradient={iconUrl ? undefined : getCategoryGradient(categories)}
           backgroundImage={iconUrl ? `url(${iconUrl})` : undefined}
           backgroundSize="cover"
           backgroundPosition="center"
           rounded="lg"
-          p={4}
           h="250px"
           w="full"
-          display="flex"
-          flexDirection="column"
-          justifyContent="flex-end"
-          alignItems="center"
           position="relative"
           overflow="hidden"
           boxShadow={isCenter ? "0 14px 28px rgba(0,0,0,0.45)" : "0 6px 18px rgba(0,0,0,0.3)"}
@@ -104,59 +101,7 @@ const GameCard: React.FC<GameCardProps> = memo(({
             borderColor: "whiteAlpha.400",
             boxShadow: "0 18px 32px rgba(0,0,0,0.5)",
           }}
-        >
-          {/* グラデーションオーバーレイ */}
-          <Box
-            position="absolute"
-            top={0}
-            left={0}
-            right={0}
-            bottom={0}
-            bgGradient="linear(to-t, blackAlpha.800, blackAlpha.0)"
-            zIndex={1}
-          />
-
-          {/* テキストコンテンツ */}
-          <Stack
-            direction="column"
-            gap={2}
-            textAlign="center"
-            w="full"
-            zIndex={2}
-          >
-            <Text
-              fontSize="sm"
-              color="whiteAlpha.700"
-              fontWeight="500"
-              textTransform="uppercase"
-              letterSpacing="wider"
-            >
-              {categories[0] || 'ゲーム'}
-            </Text>
-            <Text
-              fontSize={isCenter ? 'md' : 'sm'}
-              fontWeight="bold"
-              color="white"
-              lineHeight="tight"
-              lineClamp={isCenter ? 3 : 2}
-              transition="font-size 0.3s ease"
-            >
-              {title}
-            </Text>
-          </Stack>
-
-          {/* 非クリック可能時のオーバーレイ */}
-          {!isCenter && (
-            <Box
-              position="absolute"
-              inset={0}
-              rounded="lg"
-              bg="blackAlpha.300"
-              zIndex={3}
-              transition="background-color 0.3s ease"
-            />
-          )}
-        </Box>
+        />
       </Box>
     );
   }
@@ -187,15 +132,20 @@ const GameCard: React.FC<GameCardProps> = memo(({
             aspectRatio={1}
             bg="gray.700"
             rounded="lg"
+            position="relative"
+            overflow="hidden"
             display="flex"
             alignItems="center"
             justifyContent="center"
           >
             {iconUrl ? (
-              <img 
-                src={iconUrl} 
-                alt={title} 
-                style={{ width: '50%', height: '50%', objectFit: 'cover' }} 
+              <Image
+                src={iconUrl}
+                alt={title}
+                fill
+                sizes="(max-width: 768px) 45vw, 200px"
+                style={{ objectFit: "cover" }}
+                loading="lazy"
               />
             ) : (
               <Text fontSize="2xl">🎮</Text>

--- a/lib/overlayComments.ts
+++ b/lib/overlayComments.ts
@@ -1,11 +1,5 @@
 import { OverlayComment } from "@/types/overlayComment";
 
-const FALLBACK_COMMENTS: OverlayComment[] = [
-  { id: "fallback-1", content: "このゲーム最高！", createdAt: new Date().toISOString() },
-  { id: "fallback-2", content: "操作性が気持ちいい", createdAt: new Date().toISOString() },
-  { id: "fallback-3", content: "週末はこれで遊びます", createdAt: new Date().toISOString() },
-];
-
 /**
  * 一言コメントを取得する API
  */
@@ -20,10 +14,9 @@ export async function fetchOverlayCommentsAPI(gameId: string): Promise<OverlayCo
     }
 
     const comments = (await response.json()) as OverlayComment[];
-    const result = comments.length > 0 ? comments : FALLBACK_COMMENTS;
-    return result;
+    return comments;
   } catch (error) {
     console.error("Failed to fetch overlay comments", error);
-    return FALLBACK_COMMENTS;
+    return [];
   }
 }

--- a/types/game.ts
+++ b/types/game.ts
@@ -157,6 +157,8 @@ export interface Game {
   featuredRecommended?: boolean;
   /** 対応プラットフォーム */
   platforms?: GamePlatform[];
+  /** 初回リリース日のunix秒（ある場合） */
+  firstReleaseDate?: number | null;
 }
 
 /**


### PR DESCRIPTION
## 概要
- ホーム画面のゲーム表示が重かったため、データ取得やレンダリングの仕組みを見直して体感速度を改善しました。
- ゲーム詳細ページで存在しない DeepL API にアクセスしていた処理を削除し、不要なエラー表示を解消しました。

## 変更内容
- メーカー別セクションをホバー時にすぐ描画するのではなく、Intersection Observer を使ってスクロール後に読み込むよう調整。
- hover 時に対象ゲームのルートと詳細データを事前にプリフェッチして、詳細ページへの遷移をスムーズに。
- コメントのフォールバックやプレフェッチ量を調整し、余計な API アクセスを削減。
- ゲームカードの画像を `next/image` に置き換えて画像の最適化と遅延読み込みを実現。
- 詳細ページの DeepL 呼び出しを全面削除し、IGDB のレスポンスをそのまま扱うシンプルな実装に変更。

## 動作確認
- `npm run dev` でホーム → 詳細ページの遷移を確認。
- ブラウザで hover → クリックまでの挙動を確認し、エラーが出ないことを確認（既知の lint エラーは未対応）。
