### PR TITLE
ゲーム詳細データのプリフェッチとキャッシュを導入

### DIFF
--- a/app/category/page.tsx
+++ b/app/category/page.tsx
@@ -7,6 +7,7 @@ import PageLoader from "@/components/organisms/Loading/PageLoader";
 import { useOverlayComments } from "@/hooks/comments/useOverlayComments";
 import { usePageLoad } from "@/hooks/usePageLoad";
 import { fetchOverlayCommentsAPI } from "@/lib/overlayComments";
+import { prefetchGameOverview } from "@/lib/api/gameOverview";
 import { Game, GameCategory, ALL_GAME_CATEGORIES } from "@/types/game";
 
 const CategoryPage: React.FC = () => {
@@ -106,6 +107,7 @@ const CategoryPage: React.FC = () => {
         prefetchedRoutesRef.current.delete(route);
       }
     }
+    void prefetchGameOverview(gameId);
   }, [router, startHover]);
 
   const handleGameLeave = useCallback(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import SearchWithResults from "@/components/organisms/search/SearchWithResults";
 import HorizontalGameList from "@/components/organisms/game/HorizontalGameList";
 import OverlayComments from "@/components/organisms/CommentSection/OverlayComments";
 import { fetchOverlayCommentsAPI } from "@/lib/overlayComments";
+import { prefetchGameOverview } from "@/lib/api/gameOverview";
 import { Game } from "@/types/game";
 import type { OverlayComment, FloatingComment } from "@/types/overlayComment";
 
@@ -510,6 +511,7 @@ const handleGameHover = useCallback((gameId: string) => {
       prefetchedGameRoutesRef.current.delete(route);
     }
   }
+  void prefetchGameOverview(gameId);
 }, [router]);
 
 const handleGameLeave = useCallback(() => {

--- a/lib/cache/gameOverviewCache.ts
+++ b/lib/cache/gameOverviewCache.ts
@@ -1,0 +1,61 @@
+import type { GameOverviewData } from "@/types/game-detail";
+
+type CacheEntry = {
+  data: GameOverviewData | null;
+  error: string | null;
+  timestamp: number;
+};
+
+type CacheSnapshot = {
+  data: GameOverviewData | null;
+  error: string | null;
+  isStale: boolean;
+};
+
+const CACHE_TTL_MS = 1000 * 60 * 5; // 5 minutes
+const EXPIRATION_MS = CACHE_TTL_MS * 2;
+
+const gameOverviewCache = new Map<string, CacheEntry>();
+
+function pruneIfExpired(id: string, entry: CacheEntry | undefined): CacheEntry | undefined {
+  if (!entry) return undefined;
+  const age = Date.now() - entry.timestamp;
+  if (age > EXPIRATION_MS) {
+    gameOverviewCache.delete(id);
+    return undefined;
+  }
+  return entry;
+}
+
+export function readGameOverviewCache(gameId: string): CacheSnapshot | null {
+  const entry = pruneIfExpired(gameId, gameOverviewCache.get(gameId));
+  if (!entry) {
+    return null;
+  }
+  const age = Date.now() - entry.timestamp;
+  return {
+    data: entry.data,
+    error: entry.error,
+    isStale: age > CACHE_TTL_MS,
+  };
+}
+
+export function writeGameOverviewCache(
+  gameId: string,
+  data: GameOverviewData | null,
+  error: string | null
+) {
+  gameOverviewCache.set(gameId, {
+    data,
+    error,
+    timestamp: Date.now(),
+  });
+}
+
+export function clearGameOverviewCache(gameId?: string) {
+  if (typeof gameId === "string") {
+    gameOverviewCache.delete(gameId);
+    return;
+  }
+  gameOverviewCache.clear();
+}


### PR DESCRIPTION
## 目的
- ホーム/カテゴリから詳細ページに遷移する時の待ち時間を短くする
- 一度取得したゲーム詳細を戻る操作でもすぐ再表示できるようにする

## 変更点
- `lib/cache/gameOverviewCache.ts` でゲーム概要データ用のメモリキャッシュを実装
- `lib/api/gameOverview.ts` にキャッシュ参照・更新と `prefetchGameOverview` 関数を追加
- `lib/queries/useGameOverview.ts` をキャッシュ優先の読み込み＋必要時のみ再フェッチするようリファクタリング
- `app/page.tsx` と `app/category/page.tsx` でゲームカードのホバー時にルート遷移のプリフェッチに加えて概要データも事前取得

## 動作確認
- `npm run dev` を起動し、ホームからゲーム詳細ページへ遷移 → すぐ戻る → 再度同じゲームを開いて表示が速いことを確認
- カテゴリページでも同様にホバー後の遷移がスムーズになることを確認
